### PR TITLE
feat: implement dark mode toggle with Day (Cream) and Night (Dark Woo…

### DIFF
--- a/app.js
+++ b/app.js
@@ -160,10 +160,45 @@ class LibraryManager {
     }
 }
 
+class ThemeManager {
+    constructor() {
+        this.themeKey = 'bibliodrift_theme';
+        this.toggleBtn = document.getElementById('themeToggle');
+        this.currentTheme = localStorage.getItem(this.themeKey) || 'day';
+        
+        this.init();
+    }
+
+    init() {
+        if (!this.toggleBtn) return;
+        
+        this.applyTheme(this.currentTheme);
+        
+        this.toggleBtn.addEventListener('click', () => {
+            this.currentTheme = this.currentTheme === 'day' ? 'night' : 'day';
+            this.applyTheme(this.currentTheme);
+            localStorage.setItem(this.themeKey, this.currentTheme);
+        });
+    }
+
+    applyTheme(theme) {
+        document.documentElement.setAttribute('data-theme', theme);
+        const icon = this.toggleBtn.querySelector('i');
+        if (theme === 'night') {
+            icon.classList.remove('fa-moon');
+            icon.classList.add('fa-sun');
+        } else {
+            icon.classList.remove('fa-sun');
+            icon.classList.add('fa-moon');
+        }
+    }
+}
+
 // Init
 document.addEventListener('DOMContentLoaded', () => {
     const renderer = new BookRenderer();
     const libManager = new LibraryManager();
+    const themeManager = new ThemeManager();
 
     // Search Handler
     const searchInput = document.getElementById('searchInput');

--- a/auth.html
+++ b/auth.html
@@ -14,22 +14,24 @@
         .auth-container {
             max-width: 400px;
             margin: 6rem auto;
-            background: #fff;
+            background: var(--book-bg);
             padding: 3rem;
             border-radius: 8px;
             box-shadow: var(--shadow-soft);
             text-align: center;
-            border: 1px solid rgba(0, 0, 0, 0.05);
+            border: 1px solid var(--input-border);
+            color: var(--text-main);
         }
 
         .auth-input {
             width: 100%;
             padding: 1rem;
             margin-bottom: 1rem;
-            border: 1px solid #ddd;
+            border: 1px solid var(--input-border);
             border-radius: 4px;
             font-family: 'Georgia', serif;
-            background: #FAFAFA;
+            background: var(--input-bg);
+            color: var(--text-main);
         }
 
         .auth-btn {
@@ -74,6 +76,9 @@
                 <a href="library.html">My Library</a>
                 <a href="auth.html" class="active">Sign In</a>
             </nav>
+            <button id="themeToggle" class="btn-icon" title="Toggle Theme">
+                <i class="fa-solid fa-moon"></i>
+            </button>
         </div>
     </header>
 

--- a/index.html
+++ b/index.html
@@ -33,6 +33,9 @@
                 <a href="library.html">My Library</a>
                 <a href="auth.html">Sign In</a>
             </nav>
+            <button id="themeToggle" class="btn-icon" title="Toggle Theme">
+                <i class="fa-solid fa-moon"></i>
+            </button>
         </div>
     </header>
 

--- a/library.html
+++ b/library.html
@@ -28,6 +28,9 @@
                 <a href="library.html" class="active">My Library</a>
                 <a href="auth.html">Sign In</a>
             </nav>
+            <button id="themeToggle" class="btn-icon" title="Toggle Theme">
+                <i class="fa-solid fa-moon"></i>
+            </button>
         </div>
     </header>
 

--- a/style.css
+++ b/style.css
@@ -1,20 +1,19 @@
 :root {
-    /* Palette: Cozy Bookstore */
+    /* Day Theme (Default) */
     --bg-color: #F9F7F2;
-    /* Warm Cream */
+    --header-bg: rgba(249, 247, 242, 0.8);
     --text-main: #2C2420;
-    /* Dark Roast Coffee */
     --text-muted: #6B5E55;
-    /* Old Paper */
     --accent-gold: #D4AF37;
-    /* Gold Leaf */
     --wood-dark: #5D4037;
-    /* Walnut Shelf */
     --wood-light: #8D6E63;
-    /* Oak */
     --glass-bg: rgba(255, 255, 255, 0.1);
     --glass-border: rgba(255, 255, 255, 0.2);
     --shadow-soft: 0 10px 30px rgba(0, 0, 0, 0.05);
+    --input-bg: rgba(255, 255, 255, 0.5);
+    --input-border: rgba(0, 0, 0, 0.1);
+    --book-bg: #fff;
+    --paper-color: #fffdf9;
 
     /* Vibe Colors */
     --vibe-mystery: #78909c;
@@ -25,6 +24,24 @@
     --book-width: 160px;
     --book-height: 240px;
     --book-thick: 40px;
+}
+
+[data-theme='night'] {
+    /* Night Theme (Dark Wood) */
+    --bg-color: #1e1a18;
+    --header-bg: rgba(30, 26, 24, 0.85);
+    --text-main: #e0d5cb;
+    --text-muted: #a89a8e;
+    --accent-gold: #fccb4e;
+    --wood-dark: #3e2723;
+    --wood-light: #5d4037;
+    --glass-bg: rgba(0, 0, 0, 0.3);
+    --glass-border: rgba(255, 255, 255, 0.05);
+    --shadow-soft: 0 10px 40px rgba(0, 0, 0, 0.4);
+    --input-bg: rgba(0, 0, 0, 0.2);
+    --input-border: rgba(255, 255, 255, 0.1);
+    --book-bg: #2c2420;
+    --paper-color: #e0d5cb;
 }
 
 * {
@@ -59,8 +76,9 @@ header {
     position: sticky;
     top: 0;
     z-index: 100;
-    background: rgba(249, 247, 242, 0.8);
+    background: var(--header-bg);
     backdrop-filter: blur(10px);
+    transition: background 0.5s ease;
 }
 
 .header-controls {
@@ -76,8 +94,8 @@ header {
 }
 
 .search-input {
-    background: rgba(255, 255, 255, 0.5);
-    border: 1px solid rgba(0, 0, 0, 0.1);
+    background: var(--input-bg);
+    border: 1px solid var(--input-border);
     padding: 0.5rem 1rem;
     border-radius: 20px;
     font-family: 'Georgia', serif;
@@ -88,7 +106,7 @@ header {
 }
 
 .search-input:focus {
-    background: #fff;
+    background: var(--book-bg);
     width: 300px;
     box-shadow: var(--shadow-soft);
 }
@@ -218,7 +236,7 @@ main {
 }
 
 .book__face--front {
-    background: #fff;
+    background: var(--book-bg);
     transform: rotateY(0deg);
     z-index: 2;
 }
@@ -232,14 +250,15 @@ main {
 
 .book__face--back {
     transform: rotateY(180deg);
-    background: #fffdf9;
+    background: var(--paper-color);
     /* Paper color */
     padding: 1.5rem;
     display: flex;
     flex-direction: column;
     justify-content: space-between;
-    border: 1px solid #eee;
+    border: 1px solid var(--glass-border);
     z-index: 1;
+    color: #2C2420; /* Keep text dark for paper feel even in night mode */
 }
 
 /* The Spine */
@@ -429,4 +448,17 @@ main {
         opacity: 1;
         transform: translateY(0);
     }
+}
+
+/* Theme Toggle Button Enhancement */
+#themeToggle {
+    font-size: 1.4rem;
+    color: var(--text-main);
+    cursor: pointer;
+    transition: transform 0.3s ease, color 0.3s ease;
+}
+
+#themeToggle:hover {
+    transform: rotate(15deg) scale(1.1);
+    color: var(--accent-gold);
 }


### PR DESCRIPTION
### Description 

What does this PR do?

This PR introduces a Dark Mode / Light Mode theme toggle that allows users to switch between Day (Cream) and Night (Dark Wood) themes across the application.

--> Theme System Refactor
Converted style.css to use CSS variables for colors, inputs, and UI elements for scalable theming.

--> Theme Toggle Logic
Added a ThemeManager in app.js to handle theme switching and icon updates.

-->Persistence
Stored user theme preference in localStorage so it remains after refresh.

--> Cross-Page Integration
Theme toggle now works on Discovery, My Library, and Sign In pages.
 
## Checklist

[x]Toggle works correctly on all pages
[x]Theme preference persists after refresh
[x]Text and UI elements remain readable in dark mode
[x]Smooth CSS transitions implemented for theme switching

fixes Issue #2 