### PR TITLE
feat: Implement drag-and-drop and dropdown to move books between shelves

### DIFF
--- a/library-3d.js
+++ b/library-3d.js
@@ -303,13 +303,58 @@ class BookshelfRenderer3D {
         container.innerHTML = '';
 
         books.forEach((book, index) => {
-            const bookSpine = this.createBookSpine(book, index);
+            const bookSpine = this.createBookSpine(book, index, shelfType);
             container.appendChild(bookSpine);
         });
+
+        // Add Shelf Drop Zone Logic
+        // Remove old listeners? It's hard without named functions. 
+        // But since we clear innerHTML, we just re-attach to the container? No, container is persistent.
+        // We should be careful about duplicate listeners on the container.
+        
+        // A simple way to avoid duplicates is to set a custom property or remove and re-add.
+        // Or better, just attach these once in init() if possible, but we need shelfType reference.
+        // Since renderShelf is called multiple times, we should check if listeners are attached.
+        
+        if (!container.dataset.dropListenersAttached) {
+            container.addEventListener('dragover', (e) => {
+                e.preventDefault(); // Essential for drop
+                container.style.backgroundColor = 'rgba(255, 255, 255, 0.1)';
+            });
+
+            container.addEventListener('dragleave', (e) => {
+                container.style.backgroundColor = '';
+            });
+
+            container.addEventListener('drop', (e) => {
+                e.preventDefault();
+                container.style.backgroundColor = '';
+                const bookId = e.dataTransfer.getData('bookId');
+                const sourceShelf = e.dataTransfer.getData('sourceShelf');
+
+                if (bookId && sourceShelf && sourceShelf !== shelfType) {
+                    this.moveBook(bookId, sourceShelf, shelfType);
+                }
+            });
+            container.dataset.dropListenersAttached = 'true';
+        }
     }
 
-    createBookSpine(book, index) {
+    createBookSpine(book, index, shelfType) {
         const spine = document.createElement('div');
+
+        // Drag and Drop Attributes
+        spine.draggable = true;
+        spine.addEventListener('dragstart', (e) => {
+            e.dataTransfer.setData('bookId', book.id);
+            e.dataTransfer.setData('sourceShelf', shelfType);
+            e.dataTransfer.effectAllowed = 'move';
+            spine.style.opacity = '0.5';
+        });
+        
+        spine.addEventListener('dragend', (e) => {
+            spine.style.opacity = '1';
+        });
 
         // Generate deterministic traits
         const traits = this.generateSpineTraits(book);
@@ -584,6 +629,50 @@ class BookshelfRenderer3D {
             `).join('');
         }
 
+        // Handle Shelf Selection
+        const shelfSelect = document.getElementById('modal-shelf-select');
+        const removeBtn = document.getElementById('modal-remove-btn');
+        
+        if (shelfSelect) {
+            // Find current shelf
+            const storageKey = 'bibliodrift_library';
+            const localLibrary = JSON.parse(localStorage.getItem(storageKey)) || {};
+            let currentShelf = 'current'; // Default
+            
+            ['current', 'want', 'finished'].forEach(shelf => {
+                const found = (localLibrary[shelf] || []).find(b => b.id === book.id || (b.volumeInfo && b.id === book.id));
+                if (found) currentShelf = shelf;
+            });
+            
+            shelfSelect.value = currentShelf;
+            
+            // Remove old listeners to avoid duplicates by cloning
+            const newSelect = shelfSelect.cloneNode(true);
+            shelfSelect.parentNode.replaceChild(newSelect, shelfSelect);
+            
+            newSelect.addEventListener('change', (e) => {
+                const newShelf = e.target.value;
+                this.moveBook(book.id, currentShelf, newShelf);
+                currentShelf = newShelf; // Update local tracker
+                
+                // Close modal after move? Optional. Let's keep it open but maybe show feedback.
+                // For now, shelf re-render happens in background.
+            });
+        }
+        
+        if (removeBtn) {
+            // Remove old listeners
+            const newRemoveBtn = removeBtn.cloneNode(true);
+            removeBtn.parentNode.replaceChild(newRemoveBtn, removeBtn);
+            
+            newRemoveBtn.addEventListener('click', () => {
+                if(confirm('Are you sure you want to remove this book from your library?')) {
+                    this.removeBook(book.id);
+                    this.closeModal();
+                }
+            });
+        }
+
         // Show modal
         if (this.modal) {
             this.modal.classList.add('active');
@@ -710,6 +799,60 @@ class BookshelfRenderer3D {
 
         localStorage.setItem(storageKey, JSON.stringify(library));
         console.log(`Added ${book.title} to library`);
+    }
+
+    moveBook(bookId, fromShelf, toShelf) {
+        if (fromShelf === toShelf) return;
+
+        const storageKey = 'bibliodrift_library';
+        const localLibrary = JSON.parse(localStorage.getItem(storageKey)) || {};
+        
+        // Find existing lists
+        if (!localLibrary[fromShelf]) localLibrary[fromShelf] = [];
+        if (!localLibrary[toShelf]) localLibrary[toShelf] = [];
+
+        // Find the book index
+        const bookIndex = localLibrary[fromShelf].findIndex(b => b.id === bookId || (b.volumeInfo && b.id === bookId));
+        
+        if (bookIndex === -1) {
+            console.error("Book not found in source shelf");
+            return;
+        }
+
+        const book = localLibrary[fromShelf][bookIndex];
+        
+        // Remove from old shelf
+        localLibrary[fromShelf].splice(bookIndex, 1);
+        
+        // Add to new shelf
+        localLibrary[toShelf].push(book);
+        
+        // Save and refresh
+        localStorage.setItem(storageKey, JSON.stringify(localLibrary));
+        this.refreshShelves();
+        
+        // Visual Feedback (optional)
+        console.log(`Moved book ${bookId} from ${fromShelf} to ${toShelf}`);
+    }
+
+    removeBook(bookId) {
+        const storageKey = 'bibliodrift_library';
+        const localLibrary = JSON.parse(localStorage.getItem(storageKey)) || {};
+
+        let removed = false;
+        ['current', 'want', 'finished'].forEach(shelf => {
+            const index = (localLibrary[shelf] || []).findIndex(b => b.id === bookId || (b.volumeInfo && b.id === bookId));
+            if (index !== -1) {
+                localLibrary[shelf].splice(index, 1);
+                removed = true;
+            }
+        });
+
+        if (removed) {
+            localStorage.setItem(storageKey, JSON.stringify(localLibrary));
+            this.refreshShelves();
+            console.log(`Removed book ${bookId}`);
+        }
     }
 
     getStarRating(rating) {

--- a/library.html
+++ b/library.html
@@ -200,13 +200,15 @@
                         </div>
 
                         <div class="book-actions-section">
-                            <button class="action-btn-primary add-to-library" id="modal-add-btn">
-                                <i class="fa-regular fa-heart"></i>
-                                Add to Library
-                            </button>
-                            <button class="action-btn-primary mark-read" id="modal-read-btn">
-                                <i class="fa-solid fa-check"></i>
-                                Mark as Read
+                            <label for="modal-shelf-select" style="margin-right: 10px; font-weight: bold;">Move to Shelf:</label>
+                            <select id="modal-shelf-select" class="shelf-select" style="padding: 0.5rem; border-radius: 5px; border: 1px solid #ccc;">
+                                <option value="current">Currently Immersed</option>
+                                <option value="want">Anticipated Journeys</option>
+                                <option value="finished">Lifetime Favorites</option>
+                            </select>
+                            <button class="action-btn-primary remove-from-library" id="modal-remove-btn" style="margin-left: 10px; background-color: #ff4d4d;">
+                                <i class="fa-solid fa-trash"></i>
+                                Remove
                             </button>
                         </div>
                     </div>


### PR DESCRIPTION
### Description
This PR implements the functionality to move books between shelves using both drag-and-drop interactions and a dropdown menu in the book detail modal. This addresses issue #24.

### Changes Made
- **Implemented Drag-and-Drop:**
  - Users can now drag books between the "Currently Immersed", "Anticipated Journeys", and "Lifetime Favorites" shelves in the 3D library view.
  - Added visual feedback during drag operations.
- **Enhanced Book Detail Modal:**
  - Replaced the static "Add to Library" button with a dynamic "Move to Shelf" dropdown that reflects the book's current shelf.
  - Added a "Remove" button to delete books from the library.
- **Library Logic Updates:**
  - Added `moveBook` and `removeBook` methods to `BookshelfRenderer3D` to handle state updates and local storage synchronization.
  - Added event listeners for shelf changes within the modal.

### Related Issue
Closes #24

https://github.com/user-attachments/assets/6a4fd3e3-27a6-4673-8bfc-a2ed42a79bb9
