### PR TITLE
feat: Add new, popular, and genre badges to books (Fixes #13)

### DIFF
--- a/app.js
+++ b/app.js
@@ -124,11 +124,28 @@ class BookRenderer {
         const scene = document.createElement('div');
         scene.className = 'book-scene';
 
+        // Badge Logic
+        let badgesHTML = '';
+        const isNew = bookData.date_added && (new Date() - new Date(bookData.date_added)) < (7 * 24 * 60 * 60 * 1000);
+        const isPopular = volumeInfo.ratingsCount && volumeInfo.ratingsCount > 1000;
+        
+        if (isNew || isPopular || categories.length > 0) {
+            badgesHTML += '<div class="book-badge-container">';
+            if (isNew) badgesHTML += '<span class="book-badge badge-new">New</span>';
+            if (isPopular) badgesHTML += '<span class="book-badge badge-popular">Popular</span>';
+            if (categories.length > 0) {
+                const mainGenre = categories[0].split(' / ')[0]; // Take first category part
+                badgesHTML += `<span class="book-badge badge-genre" title="${mainGenre}">${mainGenre}</span>`;
+            }
+            badgesHTML += '</div>';
+        }
+
         // Load flip sound
         const flipSound = new Audio('assets/sounds/page-flip.mp3');
         flipSound.volume = 0.5;
 
         scene.innerHTML = `
+            ${badgesHTML}
             <div class="book" data-id="${id}">
                 <div class="book__face book__face--front">
                     <img src="${thumb.replace('http:', 'https:')}" alt="${title}">
@@ -807,10 +824,28 @@ class GenreManager {
             const thumbnail = info.imageLinks ?
                 (info.imageLinks.thumbnail || info.imageLinks.smallThumbnail) :
                 'https://via.placeholder.com/128x196?text=No+Cover';
+            const categories = info.categories || [];
+
+            // Badge Logic
+            let badgesHTML = '';
+            const isNew = book.date_added && (new Date() - new Date(book.date_added)) < (7 * 24 * 60 * 60 * 1000);
+            const isPopular = info.ratingsCount && info.ratingsCount > 1000;
+            
+            if (isNew || isPopular || categories.length > 0) {
+                badgesHTML += '<div class="book-badge-container">';
+                if (isNew) badgesHTML += '<span class="book-badge badge-new">New</span>';
+                if (isPopular) badgesHTML += '<span class="book-badge badge-popular">Popular</span>';
+                if (categories.length > 0) {
+                    const mainGenre = categories[0].split(' / ')[0]; // Take first category part
+                    badgesHTML += `<span class="book-badge badge-genre" title="${mainGenre}">${mainGenre}</span>`;
+                }
+                badgesHTML += '</div>';
+            }
 
             const card = document.createElement('div');
             card.className = 'genre-book-card';
             card.innerHTML = `
+                ${badgesHTML}
                 <img src="${thumbnail}" alt="${title}" loading="lazy">
                 <div class="genre-book-info">
                     <h4>${title}</h4>
@@ -1314,3 +1349,4 @@ if (document.readyState === 'loading') {
 } else {
     KeyboardShortcuts.init();
 }
+

--- a/style.css
+++ b/style.css
@@ -287,6 +287,7 @@ main {
 
 /* --- 3D Book Component --- */
 .book-scene {
+    position: relative;
     width: var(--book-width);
     height: var(--book-height);
     perspective: 1000px;
@@ -1833,6 +1834,7 @@ main {
 }
 
 .genre-book-card {
+    position: relative;
     background: var(--card-bg);
     border-radius: 12px;
     overflow: hidden;
@@ -6585,4 +6587,86 @@ main {
 .btn-outline:hover {
     background-color: var(--wood-dark);
     color: #fff;
+}
+
+ . b o o k - b a d g e - c o n t a i n e r   { 
+         p o s i t i o n :   a b s o l u t e ; 
+         t o p :   - 1 0 p x ; 
+         r i g h t :   - 1 0 p x ; 
+         d i s p l a y :   f l e x ; 
+         f l e x - d i r e c t i o n :   c o l u m n ; 
+         g a p :   5 p x ; 
+         z - i n d e x :   1 0 ; 
+         p o i n t e r - e v e n t s :   n o n e ; 
+ } 
+ 
+ . b o o k - b a d g e   { 
+         p a d d i n g :   4 p x   8 p x ; 
+         b o r d e r - r a d i u s :   1 2 p x ; 
+         f o n t - s i z e :   0 . 7 5 r e m ; 
+         f o n t - w e i g h t :   b o l d ; 
+         c o l o r :   w h i t e ; 
+         t e x t - t r a n s f o r m :   u p p e r c a s e ; 
+         b o x - s h a d o w :   0   2 p x   4 p x   r g b a ( 0 , 0 , 0 , 0 . 2 ) ; 
+         l e t t e r - s p a c i n g :   0 . 5 p x ; 
+ } 
+ 
+ . b a d g e - n e w   { 
+         b a c k g r o u n d - c o l o r :   # f f 4 7 5 7 ;   / *   B r i g h t   r e d   f o r   n e w   * / 
+ } 
+ 
+ . b a d g e - p o p u l a r   { 
+         b a c k g r o u n d - c o l o r :   # f f a 5 0 2 ;   / *   O r a n g e / g o l d   f o r   p o p u l a r   * / 
+ } 
+ 
+ . b a d g e - g e n r e   { 
+         b a c k g r o u n d - c o l o r :   # 2 e d 5 7 3 ;   / *   G r e e n   f o r   g e n r e ,   c o u l d   b e   d y n a m i c   * / 
+         / *   A d d   a   l i t t l e   m a x   w i d t h   i n   c a s e   o f   l o n g   g e n r e s   * / 
+         m a x - w i d t h :   8 0 p x ; 
+         w h i t e - s p a c e :   n o w r a p ; 
+         o v e r f l o w :   h i d d e n ; 
+         t e x t - o v e r f l o w :   e l l i p s i s ; 
+ } 
+ 
+ 
+ 
+
+
+.book-badge-container {
+    position: absolute;
+    top: -10px;
+    right: -10px;
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    z-index: 10;
+    pointer-events: none;
+}
+
+.book-badge {
+    padding: 4px 8px;
+    border-radius: 12px;
+    font-size: 0.75rem;
+    font-weight: bold;
+    color: white;
+    text-transform: uppercase;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+    letter-spacing: 0.5px;
+}
+
+.badge-new {
+    background-color: #ff4757; /* Bright red for new */
+}
+
+.badge-popular {
+    background-color: #ffa502; /* Orange/gold for popular */
+}
+
+.badge-genre {
+    background-color: #2ed573; /* Green for genre, could be dynamic */
+    /* Add a little max width in case of long genres */
+    max-width: 80px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }


### PR DESCRIPTION
## Description
This PR resolves #13 by introducing visual badges overlaying book covers across the platform to help users quickly identify new additions, popular books, and specific genres.

## Changes Included
- **CSS Additions (`style.css`)**: 
  - Added relative positioning logic cleanly to `.book-scene` and `.genre-book-card`.
  - Created new badge styling (`.book-badge-container`, `.book-badge`, etc.) using a vibrant color scheme (Red for New, Gold for Popular, Green for Genre).
- **DOM Injection (`app.js`)**: 
  - Updated the `createBookElement()` template strictly for the 3D book scenes to render the badges.
  - Updated the `renderBooks()` template to append the badges to the default 2D genre cards.
- **Filtering Logic**: 
  - **New**: Badges appear dynamically if the `date_added` property proves the book was saved to shelves within the last 7 days.
  - **Popular**: Renders based on evaluating `volumeInfo.ratingsCount > 1000`.
  - **Genre**: Safely maps the first element from `volumeInfo.categories` into a dynamic label.

## Testing Steps
1. Navigate to any Curated Section (e.g., *Trending books*) to see **Popular** and **Genre** Badges cleanly overlapping the tops of book covers.
2. Add a new book to your library via search, navigate to "My Library", and verify the bright red **New** badge is rendering.
3. Open the "Explore Genres" Modal to check if the 2D grid rendering properly stacks badges dynamically. 

Closes #13


https://github.com/user-attachments/assets/36d24f11-746c-44d1-84c9-75ef8cfe60d5

