### PR TITLE
Missing Rate Limiting on Authentication and Chat Endpoints

### DIFF
--- a/app.py
+++ b/app.py
@@ -93,11 +93,27 @@ def _rate_limited(endpoint: str) -> tuple[bool, int]:
     return False, 0
 
 
-def rate_limit(endpoint_name: str):
-    """Decorator to apply rate limiting to an endpoint."""
+def rate_limit(endpoint_name: str, max_requests: int = None):
+    """Decorator to apply rate limiting to an endpoint.
+    
+    Args:
+        endpoint_name: The name of the endpoint for rate limiting
+        max_requests: Optional custom max requests limit (uses RATE_LIMIT_MAX_REQUESTS if not provided)
+    """
     def decorator(f):
         def wrapped(*args, **kwargs):
-            limited, retry_after = _rate_limited(endpoint_name)
+            # Use custom max_requests if provided, otherwise use global default
+            global RATE_LIMIT_MAX_REQUESTS
+            original_max = RATE_LIMIT_MAX_REQUESTS
+            try:
+                if max_requests is not None:
+                    RATE_LIMIT_MAX_REQUESTS = max_requests
+                
+                limited, retry_after = _rate_limited(endpoint_name)
+            finally:
+                if max_requests is not None:
+                    RATE_LIMIT_MAX_REQUESTS = original_max
+                    
             if limited:
                 response = jsonify({
                     "success": False,
@@ -347,6 +363,7 @@ def handle_generate_note():
         }), 500
 
 @app.route('/api/v1/chat', methods=['POST'])
+@rate_limit('chat')
 def handle_chat():
     """Handle chat messages and generate bookseller responses."""
     try:
@@ -591,6 +608,7 @@ def sync_library():
         return jsonify({"error": str(e)}), 500
 
 @app.route('/api/v1/register', methods=['POST'])
+@rate_limit('auth', max_requests=5)
 def register():
     # Register a new user and return JWT token
     data = request.json
@@ -626,6 +644,7 @@ def register():
         return jsonify({"error": str(e)}), 400
 
 @app.route('/api/v1/login', methods=['POST'])
+@rate_limit('auth', max_requests=5)
 def login():
     # Authenticate user and return JWT token
     data = request.json


### PR DESCRIPTION
Successfully implemented rate limiting protection for the authentication and chat endpoints in app.py. The following changes were made:

- Enhanced the rate_limit decorator to accept an optional max_requests parameter for custom rate limits (default is 30 requests per minute)

- Added @rate_limit('chat') decorator to the handle_chat() function - This protects the chat endpoint with the default rate limit (30 requests per minute) to prevent API abuse and increased LLM costs

- Added @rate_limit('auth', max_requests=5) decorator to both login() and register() functions - This implements stricter rate limiting (5 requests per minute) for authentication endpoints to protect against brute force attacks

The endpoints now have the following rate limits:

- /api/v1/chat: 30 requests per minute (default)
- /api/v1/login: 5 requests per minute (stricter)
- /api/v1/register: 5 requests per minute (stricter)

closes #169