### PR TITLE
Lazy Loading Relationship Risk in ShelfItem.to_dict()

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@
 from flask import Flask, request, jsonify
 from flask_cors import CORS
 from flask_jwt_extended import JWTManager, create_access_token, jwt_required, get_jwt_identity
+from sqlalchemy.orm import joinedload
 from dotenv import load_dotenv
 import os
 from datetime import datetime, timedelta
@@ -486,7 +487,7 @@ def get_library(user_id):
         return jsonify({"error": "Unauthorized"}), 403
         
     try:
-        items = ShelfItem.query.filter_by(user_id=user_id).all()
+        items = ShelfItem.query.options(joinedload(ShelfItem.book)).filter_by(user_id=user_id).all()
         # Ensure join loads correctly or use manual load if lazy loading fails
         return jsonify({"library": [item.to_dict() for item in items]}), 200
     except Exception as e:

--- a/models.py
+++ b/models.py
@@ -58,14 +58,14 @@ class ShelfItem(db.Model):
         return {
             "id": self.id,
             "user_id": self.user_id,
-            "google_books_id": self.book.google_books_id,
-            "title": self.book.title,
-            "authors": self.book.authors,
-            "thumbnail": self.book.thumbnail,
+            "google_books_id": self.book.google_books_id if self.book else None,
+            "title": self.book.title if self.book else None,
+            "authors": self.book.authors if self.book else None,
+            "thumbnail": self.book.thumbnail if self.book else None,
             "shelf_type": self.shelf_type,
             "progress": self.progress,
             "rating": self.rating,
-            "created_at": self.created_at.isoformat()
+            "created_at": self.created_at.isoformat() if self.created_at else None
         }
 
 class BookNote(db.Model):


### PR DESCRIPTION
## Changes Made:
1. models.py - Added null checks in ShelfItem.to_dict()
The to_dict() method now checks if self.book exists before accessing its attributes:

- "google_books_id": self.book.google_books_id if self.book else None
- "title": self.book.title if self.book else None
- "authors": self.book.authors if self.book else None
- "thumbnail": self.book.thumbnail if self.book else None
- "created_at": self.created_at.isoformat() if self.created_at else None

2. app.py - Added joinedload for eager loading

- Added import: from sqlalchemy.orm import joinedload
- Updated get_library function to eagerly load the book relationship: items = ShelfItem.query.options(joinedload(ShelfItem.book)).filter_by(user_id=user_id).all()

closes #170