### PR TITLE
feat: add favicon to all HTML pages and clean up document encoding he…

### DIFF
--- a/404.html
+++ b/404.html
@@ -5,6 +5,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Page Not Found | BiblioDrift</title>
+  <link rel="icon" type="image/png" href="/biblioDrift_favicon.png" alt="BiblioDrift Logo">
   <link rel="stylesheet" href="style.css" />
   <link rel="stylesheet" href="style-responsive.css" />
 

--- a/auth.html
+++ b/auth.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Auth | BiblioDrift</title>
+    <link rel="icon" type="image/png" href="/biblioDrift_favicon.png" alt="BiblioDrift Logo">
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="style-responsive.css">
     <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600&family=Georgia&display=swap"

--- a/chat.html
+++ b/chat.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Chat with Bookseller | BiblioDrift</title>
+    <link rel="icon" type="image/png" href="/biblioDrift_favicon.png" alt="BiblioDrift Logo">
     <link rel="stylesheet" href="style.css">
     <!-- Unified Font Imports -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/index.html
+++ b/index.html
@@ -1,10 +1,11 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>BiblioDrift | Find yourself in the pages</title>
+  <link rel="icon" type="image/png" href="/biblioDrift_favicon.png" alt="BiblioDrift Logo">
   <link rel="stylesheet" href="style.css" />
 
   <!-- Fonts -->

--- a/library.html
+++ b/library.html
@@ -1,10 +1,11 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>My Library | BiblioDrift</title>
+    <link rel="icon" type="image/png" href="/biblioDrift_favicon.png" alt="BiblioDrift Logo">
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="style-responsive.css">
     <link

--- a/profile.html
+++ b/profile.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>My Profile | BiblioDrift</title>
+    <link rel="icon" type="image/png" href="/biblioDrift_favicon.png" alt="BiblioDrift Logo">
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="style-responsive.css">
     <link


### PR DESCRIPTION
Fixes #275
   
   This PR adds the BiblioDrift favicon link to all HTML pages. The favicon file (biblioDrift_favicon.png) already exists in the project root and is now properly linked in the <head> section of all HTML files (index.html, library.html, profile.html, chat.html, auth.html, 404.html).
   
   The BiblioDrift logo will now appear in browser tabs and address bars instead of the default globe icon.