### PR TITLE
Race Condition in Library Sync Can Cause Data Loss with Concurrent Modifications

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -502,10 +502,11 @@ def add_to_library():
             db.session.flush() # Flush to get book.id without committing
 
         # Check if ShelfItem exists
-        existing_item = ShelfItem.query.filter_by(user_id=validated_data.user_id, book_id=book.id).first()
+        existing_item = ShelfItem.query.filter_by(user_id=validated_data.user_id, book_id=book.id).with_for_update().first()
         if existing_item:
             # Update shelf if exists
             existing_item.shelf_type = validated_data.shelf_type.value
+            existing_item.version += 1
             item = existing_item
         else:
             item = ShelfItem(
@@ -643,16 +644,37 @@ def update_library_item(item_id):
         if not is_valid:
             return jsonify(validated_data), 400
         
-        item = ShelfItem.query.get(item_id)
+        item = ShelfItem.query.with_for_update().get(item_id)
         if not item:
             return not_found_error("Library item")
             
         if str(item.user_id) != str(current_user_id):
              return forbidden_error("Cannot modify another user's library item")
 
+        # Optimistic locking check
+        if validated_data.version is not None and item.version != validated_data.version:
+            return error_response(
+                ErrorCodes.CONFLICT, 
+                "The item has been modified on another device. Please refresh and try again.", 
+                409,
+                additional_data={"current_version": item.version, "server_item": item.to_dict()}
+            )
+
         # Update fields if provided
         if validated_data.shelf_type is not None:
             item.shelf_type = validated_data.shelf_type.value
+        
+        if validated_data.progress is not None:
+            item.progress = validated_data.progress
+            if item.progress == 100:
+                item.shelf_type = 'finished'
+                item.finished_at = datetime.utcnow()
+        
+        if validated_data.rating is not None:
+            item.rating = validated_data.rating
+
+        # Increment version on update
+        item.version += 1
             
         db.session.commit()
         return success_response(data={"message": "Item updated", "item": item.to_dict()})
@@ -709,61 +731,82 @@ def sync_library():
             return forbidden_error("Cannot sync to another user's library")
         
         synced_count = 0
+        conflicts = 0
         errors = 0
         
         for item_data in items:
             try:
-                # Validate required fields for each item
-                if not isinstance(item_data, dict):
-                    errors += 1
-                    continue
+                # Use savepoint for each item so one failure doesn't roll back the whole sync
+                with db.session.begin_nested():
+                    # Validate required fields for each item
+                    if not isinstance(item_data, dict):
+                        errors += 1
+                        continue
+                        
+                    google_id = item_data.get('id')
+                    if not google_id:
+                        errors += 1
+                        continue
                     
-                google_id = item_data.get('id')
-                if not google_id:
-                    errors += 1
-                    continue
-                
-                # 1. Ensure Book Exists
-                book = Book.query.filter_by(google_books_id=google_id).first()
-                
-                if not book:
-                    volume_info = item_data.get('volumeInfo', {})
-                    image_links = volume_info.get('imageLinks', {})
-                    authors = volume_info.get('authors', [])
-                    if isinstance(authors, list):
-                        authors = ", ".join(authors)
+                    # 1. Ensure Book Exists
+                    book = Book.query.filter_by(google_books_id=google_id).first()
+                    
+                    if not book:
+                        volume_info = item_data.get('volumeInfo', {})
+                        image_links = volume_info.get('imageLinks', {})
+                        authors = volume_info.get('authors', [])
+                        if isinstance(authors, list):
+                            authors = ", ".join(authors)
 
-                    book = Book(
-                        google_books_id=google_id,
-                        title=volume_info.get('title', 'Untitled'),
-                        authors=authors,
-                        thumbnail=image_links.get('thumbnail', '')
-                    )
-                    db.session.add(book)
-                    db.session.commit() # Need ID for next step
+                        book = Book(
+                            google_books_id=google_id,
+                            title=volume_info.get('title', 'Untitled'),
+                            authors=authors,
+                            thumbnail=image_links.get('thumbnail', '')
+                        )
+                        db.session.add(book)
+                        db.session.flush() # Get ID
 
-                # 2. Check ShelfItem
-                existing_item = ShelfItem.query.filter_by(user_id=user_id, book_id=book.id).first()
-                if not existing_item:
+                    # 2. Check ShelfItem with lock
+                    existing_item = ShelfItem.query.filter_by(user_id=user_id, book_id=book.id).with_for_update().first()
                     shelf_type = item_data.get('shelf', 'want')
-                    # Validate shelf type
                     if shelf_type not in ['want', 'current', 'finished']:
                         shelf_type = 'want'
+
+                    if not existing_item:
+                        new_item = ShelfItem(
+                            user_id=user_id,
+                            book_id=book.id,
+                            shelf_type=shelf_type,
+                            progress=item_data.get('progress', 0)
+                        )
+                        db.session.add(new_item)
+                        synced_count += 1
+                    else:
+                        # Conflict Handling / Merge Strategy
+                        remote_version = item_data.get('version')
+                        if remote_version and remote_version < existing_item.version:
+                            # Backend is newer, consider this a potential collision
+                            conflicts += 1
+                            continue 
                         
-                    new_item = ShelfItem(
-                        user_id=user_id,
-                        book_id=book.id,
-                        shelf_type=shelf_type
-                    )
-                    db.session.add(new_item)
-                    synced_count += 1
+                        # Update existing
+                        existing_item.shelf_type = shelf_type
+                        existing_item.progress = item_data.get('progress', existing_item.progress)
+                        existing_item.version += 1
+                        synced_count += 1
                     
-            except Exception:
+            except Exception as e:
+                logger.error(f"Sync error for item {item_data.get('id', 'unknown')}: {e}")
                 errors += 1
-                db.session.rollback() # Rollback on individual item error but continue
+                # begin_nested() automatically rolls back on exception within the block
         
         db.session.commit()
-        return success_response(data={"message": f"Synced {synced_count} items", "errors": errors})
+        return success_response(data={
+            "message": f"Synced {synced_count} items", 
+            "errors": errors,
+            "conflicts": conflicts
+        })
     except Exception as e:
         db.session.rollback()
         return internal_error(str(e))

--- a/backend/models.py
+++ b/backend/models.py
@@ -53,9 +53,13 @@ class ShelfItem(db.Model):
     rating = db.Column(db.Integer)
     finished_at = db.Column(db.DateTime, nullable=True)  # Timestamp when book was marked as finished
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
     # Price tracking fields
     price_alert = db.Column(db.Boolean, default=False)  # Enable/disable price alerts
     target_price = db.Column(db.Float, nullable=True)  # User's target price for alerts
+
+    # Versioning for optimistic locking
+    version = db.Column(db.Integer, default=1, nullable=False)
 
     # Relationships
     user = db.relationship('User', backref=db.backref('shelf_items', lazy=True))
@@ -75,8 +79,10 @@ class ShelfItem(db.Model):
             "rating": self.rating,
             "finished_at": self.finished_at.isoformat() if self.finished_at else None,
             "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
             "price_alert": self.price_alert,
-            "target_price": self.target_price
+            "target_price": self.target_price,
+            "version": self.version
         }
 
 class BookNote(db.Model):

--- a/backend/validators.py
+++ b/backend/validators.py
@@ -132,6 +132,7 @@ class UpdateLibraryItemRequest(BaseModel):
     shelf_type: Optional[ShelfType] = Field(default=None, description="Shelf type (want/current/finished)")
     progress: Optional[int] = Field(default=None, ge=0, le=100, description="Reading progress (0-100)")
     rating: Optional[int] = Field(default=None, ge=1, le=5, description="Book rating (1-5)")
+    version: Optional[int] = Field(default=None, description="Current version for optimistic locking")
 
 
 class SyncLibraryRequest(BaseModel):

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -235,6 +235,20 @@ class BookRenderer {
             </div>
         `;
 
+        // Interaction: Progress Slider
+        const slider = scene.querySelector('.progress-slider');
+        if (slider) {
+            slider.addEventListener('change', (e) => {
+                const newProgress = parseInt(e.target.value);
+                if (this.libraryManager) {
+                    this.libraryManager.updateBook(id, { progress: newProgress });
+                }
+                // Update small tag
+                const small = slider.nextElementSibling;
+                if (small) small.textContent = `${newProgress}% read`;
+            });
+        }
+
         // Interaction: Flip
         const bookEl = scene.querySelector('.book');
         scene.addEventListener('click', (e) => {
@@ -474,28 +488,39 @@ class LibraryManager {
                     const remoteBook = {
                         id: item.google_books_id,
                         db_id: item.id,
+                        version: item.version,
                         volumeInfo: {
                             title: item.title,
                             authors: item.authors ? item.authors.split(', ') : [],
                             imageLinks: { thumbnail: item.thumbnail }
                         },
-                        // Preserve local progress if exists, else default
-                        progress: existing ? existing.book.progress : (item.shelf_type === 'current' ? 0 : null),
+                        // Backend data is authoritative during sync DOWN
+                        progress: item.progress,
                         date_added: item.created_at || new Date().toISOString()
                     };
 
                     if (existing) {
-                        // Check if shelf matches
-                        if (existing.shelf !== item.shelf_type) {
-                            // Backend wins on shelf conflict (syncing FROM server)
-                            // Remove from old shelf
-                            this.library[existing.shelf] = this.library[existing.shelf].filter(b => b.id !== item.google_books_id);
-                            // Add to new shelf
-                            this.library[item.shelf_type].push(remoteBook);
-                        } else {
-                            // Update details (e.g. db_id might be missing locally if added offline)
-                            Object.assign(existing.book, remoteBook);
+                        const localBook = existing.book;
+                        
+                        // Conflict Resolution Logic:
+                        // If backend has a higher version, it wins.
+                        if (item.version > (localBook.version || 0)) {
+                            if (existing.shelf !== item.shelf_type) {
+                                // Remove from old shelf
+                                this.library[existing.shelf] = this.library[existing.shelf].filter(b => b.id !== item.google_books_id);
+                                // Add to new shelf
+                                this.library[item.shelf_type].push(remoteBook);
+                            } else {
+                                // Update details in place
+                                Object.assign(localBook, remoteBook);
+                            }
+                        } else if (item.version === (localBook.version || 0)) {
+                            // Versions match, just ensure db_id is set
+                            localBook.db_id = item.id;
                         }
+                        // If item.version < localBook.version, we have unsynced local changes.
+                        // syncLocalToBackend will handle pushing these.
+
                         // Mark as processed/merged
                         localBooksMap.delete(item.google_books_id);
                     } else {
@@ -541,16 +566,14 @@ class LibraryManager {
         ['current', 'want', 'finished'].forEach(shelf => {
             if (this.library[shelf]) {
                 this.library[shelf].forEach(book => {
-                    // Avoid syncing items that obviously came from backend (have db_id) 
-                    // UNLESS you want to support offline updates (which is harder).
-                    // The requirement is "upload anonymous local library when user signs up".
-                    // Anonymous items won't have db_id.
-                    if (!book.db_id) {
-                        itemsToSync.push({
-                            ...book,
-                            shelf: shelf
-                        });
-                    }
+                    // Sync both new (anonymous) items and potentially updated items (with db_id)
+                    // If book.db_id is present, it's an update. If not, it's a new item.
+                    itemsToSync.push({
+                        ...book,
+                        shelf: shelf,
+                        // Ensure version is sent if present
+                        version: book.version || 0
+                    });
                 });
             }
         });
@@ -575,12 +598,19 @@ class LibraryManager {
                 if (process.env.NODE_ENV === 'development') {
                     console.log("Sync result:", data);
                 }
-                showToast(`Synced ${data.message}`, "success");
+                
+                if (data.conflicts > 0) {
+                    showToast(`Synced ${data.message} (${data.conflicts} conflicts resolved by server)`, "info");
+                } else {
+                    showToast(`Synced ${data.message}`, "success");
+                }
 
-                // After upload, pull fresh state from backend to get the new DB IDs
+                // After upload, pull fresh state from backend to get the new DB IDs and versions
                 await this.syncWithBackend();
             } else {
-                console.error("Backend refused sync");
+                const data = await res.json();
+                console.error("Backend refused sync", data);
+                showToast("Sync failed: " + (data.error || "Server error"), "error");
             }
         } catch (e) {
             console.error("Sync upload failed", e);
@@ -677,12 +707,66 @@ class LibraryManager {
 
                 if (res.ok) {
                     const data = await res.json();
-                    // Store the DB ID back to the local object
+                    // Store the DB ID and version back to the local object
                     enrichedBook.db_id = data.item.id;
+                    enrichedBook.version = data.item.version;
                     this.saveLocally();
                 }
             } catch (e) {
                 console.error("Failed to save to backend", e);
+                showToast("Saved locally (Sync failed)", "info");
+            }
+        }
+    }
+
+
+    async updateBook(id, updates) {
+        const result = this.findBookInShelf(id);
+        if (!result) return;
+
+        const { shelf, book } = result;
+
+        // 1. Update Local State
+        Object.assign(book, updates);
+        
+        // Local "Finished" logic
+        if (updates.progress === 100 && shelf !== 'finished') {
+            // Remove from current, add to finished
+            this.library[shelf] = this.library[shelf].filter(b => b.id !== id);
+            this.library.finished.push(book);
+            showToast(`Congrats! You finished ${book.volumeInfo.title}!`, "success");
+        }
+        
+        this.saveLocally();
+
+        // 2. Update Backend
+        const user = this.getUser();
+        if (user && book.db_id) {
+            try {
+                const res = await fetch(`${this.apiBase}/library/${book.db_id}`, {
+                    method: 'PUT',
+                    headers: this.getAuthHeaders(),
+                    body: JSON.stringify({
+                        ...updates,
+                        version: book.version // Optimistic locking
+                    })
+                });
+
+                if (res.ok) {
+                    const data = await res.json();
+                    book.version = data.item.version;
+                    this.saveLocally();
+                } else if (res.status === 409) {
+                    const data = await res.json();
+                    showToast("Conflict detected! Syncing with server...", "error");
+                    // Optionally show a more detailed merge UI here
+                    await this.syncWithBackend();
+                } else {
+                    const data = await res.json();
+                    console.error("Update failed:", data.error);
+                }
+            } catch (e) {
+                console.error("Failed to update backend", e);
                 showToast("Saved locally (Sync failed)", "info");
             }
         }


### PR DESCRIPTION
Title: Race Condition in Library Sync Can Cause Data Loss with Concurrent Modifications

Labels: bug, backend, db, hard

Description:
The library sync logic in app.js (LibraryManager class) has a race condition when syncing between local storage and backend. If a user modifies their library on multiple devices/tabs simultaneously, the last-write-wins approach can cause data loss without proper conflict resolution.

Current Issues:

No optimistic locking or version tracking on ShelfItem model
syncWithBackend() overwrites local changes without checking timestamps
No transaction isolation for concurrent shelf modifications
syncLocalToBackend() doesn't handle conflicts when backend has newer data
Scenario:

User opens app on Device A and Device B
Device A adds Book X to "want" shelf (syncs to backend)
Device B (with stale data) adds Book Y, then syncs
Device B's sync may overwrite or lose Book X depending on timing
Expected Behavior:


@devanshi14malhotra 
please merge this
Closes #200 
