### PR TITLE
fix: add venv/ to .gitignore to prevent tracking local env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ __pycache__/
 # Database files
 instance/
 *.db
+# Virtual Environment
+venv/


### PR DESCRIPTION
Hi @devanshi14malhotra,

This PR addresses issue #267. I have updated the .gitignore file to include the venv/ directory.

Changes:

Added venv/ to .gitignore to ensure local Python virtual environments are not tracked by Git.

This helps keep the repository clean and prevents unnecessary local environment files from being committed.

Testing:

Verified the .gitignore file locally.

Confirmed that any folder named venv is now being ignored by the git tracking system.

Please let me know if any further changes are required. Ready for review!

#Closes #267