### PR TITLE
[NSoC'26] Fix: Prevent Dark Mode Flash on Page Navigation

### DIFF
--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -929,7 +929,8 @@ class ThemeManager {
     constructor() {
         this.themeKey = 'bibliodrift_theme';
         this.toggleBtn = document.getElementById('themeToggle');
-        this.currentTheme = SafeStorage.get(this.themeKey) || 'day';
+        const stored = SafeStorage.get(this.themeKey);
+        this.currentTheme = stored === 'night' ? 'night' : 'light';
 
         this.init();
     }
@@ -941,7 +942,7 @@ class ThemeManager {
         this.applyTheme(this.currentTheme);
 
         this.toggleBtn.addEventListener('click', () => {
-            this.currentTheme = this.currentTheme === 'day' ? 'night' : 'day';
+            this.currentTheme = this.currentTheme === 'night' ? 'light' : 'night';
             this.applyTheme(this.currentTheme);
             SafeStorage.set(this.themeKey, this.currentTheme);
         });
@@ -949,12 +950,13 @@ class ThemeManager {
 
 
     applyTheme(theme) {
-        document.documentElement.setAttribute('data-theme', theme);
         const icon = this.toggleBtn.querySelector('i');
         if (theme === 'night') {
+            document.documentElement.setAttribute('data-theme', 'night');
             icon.classList.remove('fa-moon');
             icon.classList.add('fa-sun');
         } else {
+            document.documentElement.removeAttribute('data-theme');
             icon.classList.remove('fa-sun');
             icon.classList.add('fa-moon');
         }

--- a/frontend/pages/auth.html
+++ b/frontend/pages/auth.html
@@ -3,6 +3,14 @@
 
 <head>
     <meta charset="UTF-8">
+    <script>
+        (function () {
+            const theme = localStorage.getItem('bibliodrift_theme');
+            if (theme === 'night') {
+                document.documentElement.setAttribute('data-theme', 'night');
+            }
+        })();
+    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Auth | BiblioDrift</title>
     <link rel="stylesheet" href="style.css">

--- a/frontend/pages/chat.html
+++ b/frontend/pages/chat.html
@@ -3,6 +3,14 @@
 
 <head>
     <meta charset="UTF-8">
+    <script>
+        (function () {
+            const theme = localStorage.getItem('bibliodrift_theme');
+            if (theme === 'night') {
+                document.documentElement.setAttribute('data-theme', 'night');
+            }
+        })();
+    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Chat with Bookseller | BiblioDrift</title>
     <link rel="stylesheet" href="style.css">

--- a/frontend/pages/index.html
+++ b/frontend/pages/index.html
@@ -1,8 +1,16 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 
 <head>
   <meta charset="UTF-8" />
+  <script>
+    (function () {
+        const theme = localStorage.getItem('bibliodrift_theme');
+        if (theme === 'night') {
+            document.documentElement.setAttribute('data-theme', 'night');
+        }
+    })();
+  </script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>BiblioDrift | Find yourself in the pages</title>
   <link rel="stylesheet" href="../css/style.css" />

--- a/frontend/pages/library.html
+++ b/frontend/pages/library.html
@@ -3,6 +3,14 @@
 
 <head>
     <meta charset="UTF-8">
+    <script>
+        (function () {
+            const theme = localStorage.getItem('bibliodrift_theme');
+            if (theme === 'night') {
+                document.documentElement.setAttribute('data-theme', 'night');
+            }
+        })();
+    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>My Library | BiblioDrift</title>
     <link rel="stylesheet" href="style.css">

--- a/frontend/pages/profile.html
+++ b/frontend/pages/profile.html
@@ -3,6 +3,14 @@
 
 <head>
     <meta charset="UTF-8">
+    <script>
+        (function () {
+            const theme = localStorage.getItem('bibliodrift_theme');
+            if (theme === 'night') {
+                document.documentElement.setAttribute('data-theme', 'night');
+            }
+        })();
+    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>My Profile | BiblioDrift</title>
     <link rel="stylesheet" href="style.css">


### PR DESCRIPTION
# 🔁 Pull Request

## 📌 Description
Fixed the dark mode flash issue that occurs when navigating between pages. Previously, pages would load in light mode first, then switch to dark mode after ~1 second. Now the correct theme applies instantly on page load by checking localStorage in an inline script before CSS renders.

## 🔗 Related Issue
Fixes #283 

## 🚀 Type of Change
- Bug Fix  

## 🧪 Testing
Tested by:
1. Toggled dark mode ON
2. Navigated through navbar links: Discovery, My Library, Chat, Sign In
3. Verified no white-to-brown flash appears on page load
4. Confirmed light mode continues working without any flash
5. Verified dark mode persists across page navigation


## ✅ Checklist
- [x] Code follows guidelines  
- [x] Tested properly  
- [x] No docs needed  
- [x] PR title includes **NSoC'26**

