### PR TITLE
[NSoC'26] feat: added favicon to all HTML pages

### DIFF
--- a/frontend/pages/404.html
+++ b/frontend/pages/404.html
@@ -15,6 +15,7 @@
     href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,600;1,400&family=Georgia&display=swap"
     rel="stylesheet" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+  <link rel="icon" href="../assets/images/biblioDrift_favicon.png" type="image/png">
 </head>
 
 <body class="error-page-body">
@@ -37,9 +38,9 @@
           <span class="tooltip-text"><i class="fa-solid fa-book"></i> My Library</span>
         </div>
         <div class="tooltip">
-            <a href="chat.html">Chat</a>
-            <span class="tooltip-text"><i class="fa-solid fa-comments"></i> Chat</span>
-          </div>
+          <a href="chat.html">Chat</a>
+          <span class="tooltip-text"><i class="fa-solid fa-comments"></i> Chat</span>
+        </div>
         <!-- DYNAMIC AUTH LINK -->
         <div class="tooltip">
           <a href="auth.html" id="navAuthLink">Sign In</a>
@@ -54,24 +55,25 @@
 
   <main>
     <section class="error-content-wrapper">
-        <h1 class="error-code">404</h1>
-        
-        <div class="error-book-icon">
-            <i class="fa-solid fa-book-open"></i>
-            <i class="fa-solid fa-magnifying-glass" style="font-size: 2rem; margin-left: -20px; color: var(--accent-gold);"></i>
-        </div>
+      <h1 class="error-code">404</h1>
 
-        <h2 class="error-heading">This book is missing from the shelf.</h2>
-        
-        <p class="error-subtext">
-            We've searched every aisle, checked behind the classics, and even looked in the return bin. 
-            The page you're looking for seems to have wandered off into another story.
-        </p>
+      <div class="error-book-icon">
+        <i class="fa-solid fa-book-open"></i>
+        <i class="fa-solid fa-magnifying-glass"
+          style="font-size: 2rem; margin-left: -20px; color: var(--accent-gold);"></i>
+      </div>
 
-        <div class="error-actions">
-            <a href="index.html" class="btn-primary">Return to Library</a>
-            <a href="javascript:history.back()" class="btn-outline">Go Back</a>
-        </div>
+      <h2 class="error-heading">This book is missing from the shelf.</h2>
+
+      <p class="error-subtext">
+        We've searched every aisle, checked behind the classics, and even looked in the return bin.
+        The page you're looking for seems to have wandered off into another story.
+      </p>
+
+      <div class="error-actions">
+        <a href="index.html" class="btn-primary">Return to Library</a>
+        <a href="javascript:history.back()" class="btn-outline">Go Back</a>
+      </div>
     </section>
   </main>
 

--- a/frontend/pages/auth.html
+++ b/frontend/pages/auth.html
@@ -56,6 +56,7 @@
             display: none;
         }
     </style>
+    <link rel="icon" href="../assets/images/biblioDrift_favicon.png" type="image/png">
 </head>
 
 <body>

--- a/frontend/pages/chat.html
+++ b/frontend/pages/chat.html
@@ -171,6 +171,7 @@
             }
         }
     </style>
+    <link rel="icon" href="../assets/images/biblioDrift_favicon.png" type="image/png">
 </head>
 
 <body>

--- a/frontend/pages/index.html
+++ b/frontend/pages/index.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 
 <head>
@@ -17,6 +17,7 @@
   
   <!-- Security: DOMPurify for XSS prevention -->
   <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
+  <link rel="icon" href="../assets/images/biblioDrift_favicon.png" type="image/png">
 </head>
 
 <body>

--- a/frontend/pages/library.html
+++ b/frontend/pages/library.html
@@ -11,6 +11,7 @@
         href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,600;1,400&family=Georgia&display=swap"
         rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <link rel="icon" href="../assets/images/biblioDrift_favicon.png" type="image/png">
 </head>
 
 <body>

--- a/frontend/pages/profile.html
+++ b/frontend/pages/profile.html
@@ -11,6 +11,7 @@
         href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,600;1,400&family=Georgia&display=swap"
         rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <link rel="icon" href="../assets/images/biblioDrift_favicon.png" type="image/png">
 </head>
 
 <body>


### PR DESCRIPTION
# 🔁 Pull Request

## 📌 Description
This PR adds the BiblioDrift favicon link to all HTML pages. The favicon file (biblioDrift_favicon.png) already exists in the project root and is now properly linked in the section of all HTML files (index.html, library.html, profile.html, chat.html, auth.html, 404.html).

The BiblioDrift logo will now appear in browser tabs and address bars instead of the default globe icon.

## 🔗 Related Issue
Fixes #275 

## 🚀 Type of Change 
- [ ] Feature  
- [ ] Enhancement  










