### PR TITLE
[NSoC'26] fix: fixed dark mode toggle in privacy and terms and conditions pages 

### DIFF
--- a/frontend/pages/privacy-policy.html
+++ b/frontend/pages/privacy-policy.html
@@ -3,6 +3,14 @@
 
 <head>
   <meta charset="UTF-8" />
+  <script>
+      (function () {
+          const theme = localStorage.getItem('bibliodrift_theme');
+          if (theme === 'night') {
+              document.documentElement.setAttribute('data-theme', 'night');
+          }
+      })();
+  </script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Privacy Policy | BiblioDrift</title>
   <link rel="stylesheet" href="../css/style.css" />
@@ -64,6 +72,7 @@
 
   <script src="../js/config.js"></script>
   <script src="../js/footer.js"></script>
+  <script src="../js/app.js"></script>
   <script src="../script/header-scroll.js"></script>
 </body>
 

--- a/frontend/pages/terms-and-conditions.html
+++ b/frontend/pages/terms-and-conditions.html
@@ -3,6 +3,14 @@
 
 <head>
   <meta charset="UTF-8" />
+  <script>
+      (function () {
+          const theme = localStorage.getItem('bibliodrift_theme');
+          if (theme === 'night') {
+              document.documentElement.setAttribute('data-theme', 'night');
+          }
+      })();
+  </script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Terms & Conditions | BiblioDrift</title>
   <link rel="stylesheet" href="../css/style.css" />
@@ -64,6 +72,7 @@
 
   <script src="../js/config.js"></script>
   <script src="../js/footer.js"></script>
+  <script src="../js/app.js"></script>
   <script src="../script/header-scroll.js"></script>
 </body>
 


### PR DESCRIPTION
## Description
Added dark mode support for privacy and terms and condition pages.

## Related Issue
Fixes lack of dark mode support in privacy and terms and condition pages.

## Type of Change
- [ ] Bug Fix  
- [ ] Feature  
- [x] Enhancement  
- [ ] Documentation  

## Testing
Checked out the privacy and terms and condition pages.


## Checklist
- [x] Code follows guidelines  
- [x] Tested properly  
- [x] Docs updated  
- [x] PR title includes the relevant event tag or a general contribution label

## NSoC'26 Rule
For event-based contributions, include the relevant event tag in the t itle, such as **NSoC'26**, **Apertre 3.0**,**GSSoC'26**, etc.

Example:
[NSoC'26] Add authentication system

Fixes #375 