### PR TITLE
[NSoC'26] Fix broken social links in footer Connect section

### DIFF
--- a/frontend/js/footer.js
+++ b/frontend/js/footer.js
@@ -34,7 +34,7 @@ const createFooter = () => {
         <div class="footer-social">
           <h3>Connect</h3>
           <div class="social-icons">
-            <a href="#" title="LinkedIn"><i class="fab fa-linkedin-in"></i></a>
+            <a href="https://www.linkedin.com/in/devanshi5malhotra/" target="_blank" rel="noopener noreferrer" title="LinkedIn"><i class="fab fa-linkedin-in"></i></a>
             <a href="#" title="Instagram"><i class="fab fa-instagram"></i></a>
             <a href="#" title="Facebook"><i class="fab fa-facebook-f"></i></a>
             <a href="https://github.com/devanshi14malhotra/BiblioDrift" target="_blank" rel="noopener noreferrer" title="GitHub">

--- a/frontend/pages/index.html
+++ b/frontend/pages/index.html
@@ -206,7 +206,7 @@
       <div class="footer-social">
         <h3>Connect</h3>
         <div class="social-icons">
-          <a href="#" title="LinkedIn"><i class="fab fa-linkedin-in"></i></a>
+          <a href="https://www.linkedin.com/in/devanshi5malhotra/" target="_blank" rel="noopener noreferrer" title="LinkedIn"><i class="fab fa-linkedin-in"></i></a>
           <a href="#" title="Instagram"><i class="fab fa-instagram"></i></a>
           <a href="https://github.com/devanshi14malhotra/BiblioDrift" target="_blank" rel="noopener noreferrer"
             title="GitHub"><i class="fa-brands fa-github"></i></a>


### PR DESCRIPTION
## Description
Fixed broken LinkedIn link in the footer Connect section by adding the correct URL 

## Related Issue
Fixes #386 

## Type of Change
- [x] Bug Fix  
- [ ] Feature  
- [ ] Enhancement  
- [ ] Documentation  

## Testing
Tested locally using VS Code Live Server. LinkedIn link now opens the correct profile in a new tab. Instagram and Facebook remain as placeholders.

## Screenshots
<img width="1907" height="928" alt="image" src="https://github.com/user-attachments/assets/3b9c6e4f-d27f-4008-8f36-2ff421996f1b" />

## Checklist
- [x] Code follows guidelines  
- [x] Tested properly  
- [x] Docs updated  
- [x] PR title includes the relevant event tag or a general contribution label

## NSoC'26 Rule
For event-based contributions, include the relevant event tag in the title, such as **NSoC'26**, **Apertre 3.0**,**GSSoC'26**, etc.

