### PR TITLE
fix:  Incorrect Content-Type Validation Logic in middleware.py

### DIFF
--- a/backend/middleware.py
+++ b/backend/middleware.py
@@ -145,7 +145,11 @@ def safe_request_handler(
             # Content-Type validation
             if validate_content_type and request.method not in ['GET', 'HEAD']:
                 ct = request.content_type
-                if not ct or ct.split(';')[0].strip() not in ['application/json']:
+                allowed = ['application/json'] if require_json else [
+                    'application/json',
+                    'application/x-www-form-urlencoded'
+                ]
+                if not ct or ct.split(';')[0].strip() not in allowed:
                     logger.warning(f"Content-Type validation failed for {request.path}")
                     return invalid_json_error("Invalid or missing Content-Type header")
             


### PR DESCRIPTION
Implemented the fix in middleware.py.

What changed:
- In `safe_request_handler()`, Content-Type validation now uses:
  - `['application/json']` when `require_json=True`
  - `['application/json', 'application/x-www-form-urlencoded']` when `require_json=False`
- This ensures strict JSON-only enforcement when JSON is required, while preserving broader acceptance for non-JSON handlers.

Validation:
- Checked diagnostics for middleware.py: no errors found.

closes #395