### PR TITLE
fix: prevent stale shelfType closure in drop listeners

### DIFF
--- a/frontend/js/library-3d.js
+++ b/frontend/js/library-3d.js
@@ -520,6 +520,7 @@ class BookshelfRenderer3D {
         // A simple way to avoid duplicates is to set a custom property or remove and re-add.
         // Or better, just attach these once in init() if possible, but we need shelfType reference.
         // Since renderShelf is called multiple times, we should check if listeners are attached.
+        container.dataset.shelf = shelfType;
 
         if (!container.dataset.dropListenersAttached) {
             container.addEventListener('dragover', (e) => {
@@ -529,16 +530,19 @@ class BookshelfRenderer3D {
 
             container.addEventListener('dragleave', (e) => {
                 container.style.backgroundColor = '';
+                
             });
 
             container.addEventListener('drop', (e) => {
                 e.preventDefault();
                 container.style.backgroundColor = '';
+
+                const targetShelf = e.currentTarget.dataset.shelf;
                 const bookId = e.dataTransfer.getData('bookId');
                 const sourceShelf = e.dataTransfer.getData('sourceShelf');
 
-                if (bookId && sourceShelf && sourceShelf !== shelfType) {
-                    this.moveBook(bookId, sourceShelf, shelfType);
+                if (bookId && sourceShelf && sourceShelf !== targetShelf) {
+                    this.moveBook(bookId, sourceShelf, targetShelf);
                 }
             });
             container.dataset.dropListenersAttached = 'true';


### PR DESCRIPTION
# [NSoC'26] Fix stale shelfType closure in drop listeners

## Description

Fixed an issue in `library-3d.js` where drop event listeners referenced a stale `shelfType` closure variable across shelf re-renders.

The container listeners were attached only once using `dataset.dropListenersAttached`, causing the drop callback to retain the initial `shelfType` value from the first `renderShelf()` call.

This PR resolves the issue by:

* storing the shelf type using `data-shelf`
* dynamically reading the shelf from `e.currentTarget.dataset.shelf`
* removing stale closure dependency from the drop callback

This ensures correct shelf targeting even when containers are reused after re-renders.

## Related Issue

Fixes #368 

## Type of Change

* [x] Bug Fix
* [ ] Feature
* [x] Enhancement
* [ ] Documentation

## Testing

* Verified bookshelf rendering after updates
* Tested drag-and-drop interactions between shelves
* Confirmed correct shelf targeting after re-renders
* Confirmed no new console errors related to shelf handling

## Checklist

* [x] Code follows guidelines
* [x] Tested properly
* [ ] Docs updated
* [x] PR title includes the relevant event tag or a general contribution label
