### PR TITLE
fix: safe_get_json inconsistent contract for JSON root types

### DIFF
--- a/backend/security_parsers.py
+++ b/backend/security_parsers.py
@@ -55,8 +55,9 @@ def safe_get_json(
     force: bool = False,
     silent: bool = False,
     max_size: int = MAX_JSON_SIZE_BYTES,
-    validate_type: bool = True
-) -> Tuple[bool, Optional[Dict[str, Any]], Optional[str]]:
+    validate_type: bool = True,
+    require_object: bool = True
+) -> Tuple[bool, Optional[Any], Optional[str]]:
     """
     Safely parse JSON from request body with size and depth limits.
     
@@ -65,6 +66,7 @@ def safe_get_json(
         silent: Return None instead of raising exceptions (default: False)
         max_size: Maximum allowed request body size in bytes (default: 1MB)
         validate_type: Validate Content-Type header (default: True)
+        require_object: Require the parsed JSON root to be an object/dict (default: True)
     
     Returns:
         Tuple[bool, Optional[Dict], Optional[str]]: (success, parsed_data, error_message)
@@ -123,11 +125,10 @@ def safe_get_json(
             return False, None, error_msg
         
         # Step 6: Ensure parsed data is dict-like for API payloads
-        if not isinstance(parsed_data, dict):
-            if not force:
-                error_msg = "JSON root must be an object, not array or primitive"
-                logger.warning(error_msg)
-                return False, None, error_msg
+        if require_object and not isinstance(parsed_data, dict):
+            error_msg = "JSON root must be an object, not array or primitive"
+            logger.warning(error_msg)
+            return False, None, error_msg
         
         logger.debug(f"Successfully parsed JSON payload: {len(raw_data)} bytes")
         return True, parsed_data, None

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -23,6 +23,14 @@ from backend.validators import validate_google_books_id, validate_request, AddTo
 
 class TestJSONParsing:
     """Test safe JSON parsing with malicious payloads."""
+
+    def _mock_json_request(self, payload: str, content_type: str = "application/json"):
+        mock_request = MagicMock()
+        mock_request.content_type = content_type
+        mock_request.content_length = len(payload)
+        mock_request.is_json = content_type.startswith("application/json")
+        mock_request.get_data.return_value = payload
+        return mock_request
     
     def test_oversized_json_payload(self):
         """Test that oversized JSON payloads are rejected."""
@@ -54,6 +62,28 @@ class TestJSONParsing:
             assert False, "Should have raised JSONDecodeError"
         except json.JSONDecodeError:
             pass  # Expected
+
+    def test_force_does_not_allow_non_object_root(self):
+        """Force mode should not bypass object-root validation."""
+        payload = json.dumps([{"id": 1}])
+
+        with patch("backend.security_parsers.request", self._mock_json_request(payload)):
+            success, data, error = safe_get_json(force=True)
+
+        assert not success
+        assert data is None
+        assert error == "JSON root must be an object, not array or primitive"
+
+    def test_non_object_root_allowed_when_explicitly_opted_out(self):
+        """Callers can explicitly accept array roots when they need to."""
+        payload = json.dumps([{"id": 1}])
+
+        with patch("backend.security_parsers.request", self._mock_json_request(payload)):
+            success, data, error = safe_get_json(force=True, require_object=False)
+
+        assert success
+        assert error is None
+        assert data == [{"id": 1}]
 
 
 class TestXSSSanitization:


### PR DESCRIPTION
`safe_get_json` now enforces object-root JSON independently of `force`, and it exposes an explicit opt-out via `require_object=False` for the few callers that truly want arrays or other roots. The contract change is in security_parsers.py and the root check is now unconditional when `require_object` is left at its default in security_parsers.py.

I added regression coverage in test_security.py and test_security.py for both cases: `force=True` still rejects non-object roots, and `require_object=False` accepts them. Validation passed with a direct smoke test in the project venv, and static error checks came back clean.


closes #469