### PR TITLE
Fix #449: Remove hardcoded port 5001 from chat.html

### DIFF
--- a/frontend/js/chat.js
+++ b/frontend/js/chat.js
@@ -11,9 +11,11 @@ class ChatInterface {
         this.conversationHistory = [];
         this.isProcessing = false;
 
-        // Ensure backend connection is initialized
-        if (typeof window !== 'undefined' && !window.MOOD_API_BASE) {
-            window.MOOD_API_BASE = 'http://127.0.0.1:5000/api/v1';
+        // Ensure backend connection is initialized with proper fallback
+        if (typeof window !== 'undefined') {
+            if (!window.MOOD_API_BASE || window.MOOD_API_BASE.includes(':5001')) {
+                window.MOOD_API_BASE = 'http://127.0.0.1:5000/api/v1';
+            }
         }
 
         this.init();

--- a/frontend/pages/chat.html
+++ b/frontend/pages/chat.html
@@ -369,8 +369,6 @@
     </main>
 
     <script>
-        window.MOOD_API_BASE = 'http://localhost:5001/api/v1';
-
         document.addEventListener('DOMContentLoaded', () => {
             const link = document.getElementById('navAuthLink');
             const tooltip = document.getElementById('navAuthTooltip');


### PR DESCRIPTION
## Issue
Chat requests fail because `chat.html` hardcodes `MOOD_API_BASE` to port 5001, overriding the correct port 5000 from `config.js`.

## Changes
- Removed hardcoded port 5001 override from `chat.html`
- Enhanced fallback logic in `chat.js` to detect and correct port 5001 if it somehow exists
- Chat now properly uses port 5000 as configured in `config.js`

## Testing
- Backend running on port 5000
- Open chat.html and send a message
- Verify network request goes to localhost:5000 (not 5001)
- Chat should work without errors


## Closes #449 