### PR TITLE
[NSoC'26] [GSSoC] fix: Inconsistent Content-Type validation between backend modules

### DIFF
--- a/backend/error_responses.py
+++ b/backend/error_responses.py
@@ -150,11 +150,11 @@ def missing_fields_error(fields: str) -> tuple:
     )
 
 
-def invalid_json_error() -> tuple:
-    """Return an invalid JSON error response"""
+def invalid_json_error(message: str = "Invalid JSON or missing request body") -> tuple:
+    """Return an invalid JSON error response."""
     return error_response(
         ErrorCodes.INVALID_JSON,
-        "Invalid JSON or missing request body",
+        message,
         400
     )
 

--- a/backend/middleware.py
+++ b/backend/middleware.py
@@ -5,7 +5,13 @@ Includes Content-Type validation, request size limits, and header validation.
 import logging
 from functools import wraps
 from flask import request, jsonify
-from .error_responses import invalid_json_error
+
+try:
+    from .error_responses import invalid_json_error
+    from .security_parsers import validate_content_type as _validate_content_type_header
+except ImportError:
+    from error_responses import invalid_json_error
+    from security_parsers import validate_content_type as _validate_content_type_header
 
 logger = logging.getLogger(__name__)
 
@@ -30,26 +36,14 @@ def validate_content_type_middleware(f):
         # Skip for requests without body
         if request.content_length is None or request.content_length == 0:
             return f(*args, **kwargs)
-        
-        # Validate Content-Type header
-        content_type = request.content_type
-        
-        if not content_type:
-            logger.warning(f"Request to {request.path} missing Content-Type header")
-            return invalid_json_error("Missing Content-Type header")
-        
-        # Check for JSON content type
-        base_type = content_type.split(';')[0].strip().lower()
-        
-        if base_type not in ['application/json', 'application/x-www-form-urlencoded']:
+
+        is_valid, error_message = _validate_content_type_header()
+        if not is_valid:
             logger.warning(
-                f"Invalid Content-Type '{content_type}' for {request.method} "
+                f"Invalid Content-Type '{request.content_type}' for {request.method} "
                 f"{request.path} from {request.remote_addr}"
             )
-            return invalid_json_error(
-                f"Invalid Content-Type: {content_type}. "
-                "Expected: application/json"
-            )
+            return invalid_json_error(error_message)
         
         return f(*args, **kwargs)
     
@@ -144,14 +138,14 @@ def safe_request_handler(
         def decorated_function(*args, **kwargs):
             # Content-Type validation
             if validate_content_type and request.method not in ['GET', 'HEAD']:
-                ct = request.content_type
                 allowed = ['application/json'] if require_json else [
                     'application/json',
                     'application/x-www-form-urlencoded'
                 ]
-                if not ct or ct.split(';')[0].strip() not in allowed:
+                is_valid, error_message = _validate_content_type_header(allowed)
+                if not is_valid:
                     logger.warning(f"Content-Type validation failed for {request.path}")
-                    return invalid_json_error("Invalid or missing Content-Type header")
+                    return invalid_json_error(error_message)
             
             # Size validation
             if max_size_bytes and request.content_length is not None:

--- a/backend/security_parsers.py
+++ b/backend/security_parsers.py
@@ -33,6 +33,8 @@ def validate_content_type(allowed_types: Optional[list] = None) -> Tuple[bool, O
     """
     if allowed_types is None:
         allowed_types = ['application/json', 'application/x-www-form-urlencoded']
+
+    normalized_allowed_types = [content_type.strip().lower() for content_type in allowed_types]
     
     content_type = request.content_type
     
@@ -41,10 +43,10 @@ def validate_content_type(allowed_types: Optional[list] = None) -> Tuple[bool, O
         return False, "Missing Content-Type header"
     
     # Extract base content type (without charset)
-    base_content_type = content_type.split(';')[0].strip()
+    base_content_type = content_type.split(';')[0].strip().lower()
     
     # Check if content type is in allowed list
-    if base_content_type not in allowed_types:
+    if base_content_type not in normalized_allowed_types:
         allowed_str = ', '.join(allowed_types)
         return False, f"Invalid Content-Type: {content_type}. Allowed: {allowed_str}"
     

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -9,12 +9,14 @@ import json
 import sys
 from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
+from flask import Flask, jsonify
 
 # Import security modules
 from backend.security_parsers import (
     safe_get_json, get_request_arg_safe, validate_content_type, _validate_depth,
     JSONParseError, MAX_JSON_SIZE_BYTES
 )
+from backend.middleware import validate_content_type_middleware, safe_request_handler
 from backend.sanitizer import (
     sanitize_string, sanitize_payload, contains_malicious_patterns,
     is_likely_html_attack, sanitize_for_ai, sanitize_for_display, sanitize_for_storage
@@ -393,6 +395,50 @@ class TestContentTypeValidation:
 
         assert is_valid
         assert error is None
+
+    def test_normalizes_case_and_parameters(self):
+        """Content-Type validation should ignore charset parameters and casing."""
+        with patch(
+            "backend.security_parsers.request",
+            SimpleNamespace(content_type="Application/JSON; charset=utf-8")
+        ):
+            is_valid, error = validate_content_type()
+
+        assert is_valid
+        assert error is None
+
+
+class TestMiddlewareContentTypeValidation:
+    """Test middleware Content-Type validation paths."""
+
+    def test_parameterized_form_content_type_is_accepted_consistently(self):
+        """Middleware and safe_request_handler should treat parameterized form headers the same way."""
+        app = Flask(__name__)
+
+        @app.post("/middleware")
+        @validate_content_type_middleware
+        def middleware_endpoint():
+            return jsonify({"ok": True})
+
+        @app.post("/safe")
+        @safe_request_handler(require_json=False)
+        def safe_endpoint():
+            return jsonify({"ok": True})
+
+        with app.test_client() as client:
+            middleware_response = client.post(
+                "/middleware",
+                data="name=value",
+                headers={"Content-Type": "application/x-www-form-urlencoded; charset=utf-8"},
+            )
+            safe_response = client.post(
+                "/safe",
+                data="name=value",
+                headers={"Content-Type": "application/x-www-form-urlencoded; charset=utf-8"},
+            )
+
+        assert middleware_response.status_code == 200
+        assert safe_response.status_code == 200
 
 
 class TestHTMLContentProtection:


### PR DESCRIPTION
# Pull Request

NSoC and GSSoC

## Description
I unified the Content-Type checks so all three paths use the same normalization and allowed-type logic. The shared parser in security_parsers.py now lowercases the base type before comparing, middleware.py calls that shared validator instead of duplicating its own rules, and error_responses.py now allows `invalid_json_error()` to carry the specific validation message back to the client. I also added regression coverage in test_security.py for parameterized Content-Type headers and middleware behavior.

Validation passed with a direct Flask script exercising the updated parser and both decorator paths, and `get_errors` reports no issues in the edited files. I couldn’t run the repo’s pytest module end-to-end because the existing test import layout currently trips over unrelated module-path issues before collection starts.

## Related Issue
Fixes #523

## Type of Change
- [x] Bug Fix  
- [ ] Feature  
- [ ] Enhancement  
- [ ] Documentation  



## Checklist
- [x] Code follows guidelines  
- [x] Tested properly  
- [ ] Docs updated  
- [x] PR title includes the relevant event tag or a general contribution label

Example:
[NSoC'26] Add authentication system

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Content-Type validation is now case-insensitive and properly ignores charset parameters, improving compatibility with various request formats.

* **Refactor**
  * Enhanced error messaging system for invalid requests, supporting more detailed and customizable error responses.

* **Tests**
  * Added comprehensive test coverage for Content-Type validation, including edge cases and parameterized content types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devanshi14malhotra/BiblioDrift/pull/546)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->