### PR TITLE
Enhancement: add caching for get_category_books to reduce redundant LLM calls (GSSoC'26) #576

### DIFF
--- a/backend/ai_service.py
+++ b/backend/ai_service.py
@@ -13,7 +13,8 @@ from cache_service import (
     cache_recommendations, 
     cache_mood_tags, 
     cache_chat_response,
-    cache_mood_analysis
+    cache_mood_analysis,
+    cache_category_books,
 )
 
 # Setup logging from environment
@@ -676,7 +677,7 @@ def get_ai_recommendations(query):
     
     return f"Based on your interest in '{query}', I'd recommend exploring books that capture similar themes and emotional resonance."
 
-
+@cache_category_books
 def get_category_books(category: str, vibe_description: str, count: int = 5) -> list:
     """
     Generate a list of real, relevant books for a specific shelf category.

--- a/backend/cache_service.py
+++ b/backend/cache_service.py
@@ -38,6 +38,7 @@ class CacheNamespace(Enum):
     SYSTEM = "system"
     EXTERNAL_API = "external_api"
     PRICE_TRACKER = "price_tracker"
+    CATEGORY_BOOKS = "category_books"
 
 
 class CacheConfig:
@@ -64,6 +65,7 @@ class CacheConfig:
     MOOD_TAGS_TTL = int(os.getenv('CACHE_MOOD_TAGS_TTL', 43200))
     CHAT_RESPONSE_TTL = int(os.getenv('CACHE_CHAT_RESPONSE_TTL', 1800))
     GOODREADS_SCRAPING_TTL = int(os.getenv('CACHE_GOODREADS_TTL', 604800))
+    CATEGORY_BOOKS_TTL    = int(os.getenv('CACHE_CATEGORY_BOOKS_TTL', 43200))
     
     # Cache configuration
     CACHE_TYPE = os.getenv('CACHE_TYPE', 'simple')  # 'redis', 'simple', or 'null'
@@ -374,7 +376,7 @@ def cached_result(
             # Execute and store
             try:
                 result = func(*args, **kwargs)
-                if result is not None:
+                if result:
                     cache_service.set(cache_key, result, timeout=ttl)
                 return result
             except Exception as e:
@@ -433,3 +435,18 @@ def invalidate_namespace(namespace: Union[CacheNamespace, str], identifier: Opti
     Public API to invalidate a whole namespace or specific entity.
     """
     return cache_service.clear_namespace(namespace, identifier)
+
+def cache_category_books(func):
+    """
+    Cache AI-generated book lists for virtual shelf categories.
+
+    The key encodes *all* call arguments (category name, vibe_description,
+    and count) via the hash component built by CacheKey.build(), so a
+    request for 5 books and one for 10 books for the same category are
+    stored under different keys and never collide.
+    """
+    return cached_result(
+        CacheNamespace.CATEGORY_BOOKS,
+        identifier_arg='category',   # category name is the primary key segment
+        ttl=CacheConfig.CATEGORY_BOOKS_TTL
+    )(func)

--- a/tests/test_category_cache.py
+++ b/tests/test_category_cache.py
@@ -1,0 +1,142 @@
+"""
+Fixed tests for get_category_books caching.
+Run: python -m pytest test_category_cache.py -v
+CRITICAL: make sure to transfer this file to the backend folder for correct results 
+"""
+import pytest
+from unittest.mock import patch
+from flask import Flask
+
+
+# ---------------------------------------------------------------
+# FIXTURES — run once, shared across all tests
+# ---------------------------------------------------------------
+
+@pytest.fixture(scope='module')
+def flask_app():
+    """
+    Cache needs a Flask app to initialize.
+    Without this, decorator sees is_initialized=False
+    and skips cache entirely — which is what broke all 5 tests.
+    """
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+
+    from cache_service import cache_service
+    cache_service.is_initialized = False   # force fresh init
+    cache_service.init_app(app)
+
+    return app
+
+
+@pytest.fixture(autouse=True)
+def clear_cache_between_tests(flask_app):
+    """
+    Wipe cache before every test.
+    Without this, result from test 1 bleeds into test 2.
+    """
+    with flask_app.app_context():
+        from cache_service import cache_service
+        if cache_service.cache:
+            cache_service.cache.clear()
+        yield
+
+
+# ---------------------------------------------------------------
+# Test 1
+# ---------------------------------------------------------------
+def test_ai_called_only_once_for_same_inputs(flask_app):
+    with flask_app.app_context():
+        with patch('ai_service.llm_service.is_available', return_value=True), \
+             patch('ai_service.llm_service.generate_text',
+                   return_value='[{"title":"Test Book","author":"Test Author","reason":"fits"}]') as mock_llm:
+
+            from ai_service import get_category_books
+
+            result1 = get_category_books("Rainy Reads", "quiet and melancholy", 5)
+            result2 = get_category_books("Rainy Reads", "quiet and melancholy", 5)
+            result3 = get_category_books("Rainy Reads", "quiet and melancholy", 5)
+
+            assert mock_llm.call_count == 1, (
+                f"LLM called {mock_llm.call_count} times. Expected 1. Cache broken."
+            )
+            assert result1 == result2 == result3
+
+
+# ---------------------------------------------------------------
+# Test 2
+# ---------------------------------------------------------------
+def test_different_categories_get_different_cache_keys(flask_app):
+    with flask_app.app_context():
+        with patch('ai_service.llm_service.is_available', return_value=True), \
+             patch('ai_service.llm_service.generate_text',
+                   return_value='[{"title":"Book","author":"Author","reason":"fits"}]') as mock_llm:
+
+            from ai_service import get_category_books
+
+            get_category_books("Rainy Reads", "quiet and melancholy", 5)
+            get_category_books("Adventure Shelf", "thrilling and bold", 5)
+
+            assert mock_llm.call_count == 2, (
+                f"Expected 2 LLM calls for 2 categories. Got {mock_llm.call_count}."
+            )
+
+
+# ---------------------------------------------------------------
+# Test 3
+# ---------------------------------------------------------------
+def test_different_counts_get_different_cache_keys(flask_app):
+    with flask_app.app_context():
+        with patch('ai_service.llm_service.is_available', return_value=True), \
+             patch('ai_service.llm_service.generate_text',
+                   return_value='[{"title":"Book","author":"Author","reason":"fits"}]') as mock_llm:
+
+            from ai_service import get_category_books
+
+            get_category_books("Rainy Reads", "quiet and melancholy", 5)
+            get_category_books("Rainy Reads", "quiet and melancholy", 10)
+
+            assert mock_llm.call_count == 2, (
+                f"count=5 and count=10 shared cache entry. Got {mock_llm.call_count} calls."
+            )
+
+
+# ---------------------------------------------------------------
+# Test 4
+# ---------------------------------------------------------------
+def test_cached_result_matches_original_result(flask_app):
+    with flask_app.app_context():
+        with patch('ai_service.llm_service.is_available', return_value=True), \
+             patch('ai_service.llm_service.generate_text',
+                   return_value='[{"title":"The Road","author":"Cormac McCarthy","reason":"bleak and quiet"}]'):
+
+            from ai_service import get_category_books
+
+            expected = [{"title": "The Road", "author": "Cormac McCarthy", "reason": "bleak and quiet"}]
+
+            first_call  = get_category_books("Dark Shelf", "bleak and quiet", 5)
+            second_call = get_category_books("Dark Shelf", "bleak and quiet", 5)
+
+            assert first_call == expected,  f"First call wrong: {first_call}"
+            assert second_call == expected, f"Cached call wrong: {second_call}"
+            assert first_call == second_call
+
+
+# ---------------------------------------------------------------
+# Test 5
+# ---------------------------------------------------------------
+def test_none_result_is_not_cached(flask_app):
+    with flask_app.app_context():
+        with patch('ai_service.llm_service.is_available', return_value=True), \
+             patch('ai_service.llm_service.generate_text', return_value=None) as mock_llm:
+
+            from ai_service import get_category_books
+
+            result1 = get_category_books("Broken Shelf", "some vibe", 5)
+            result2 = get_category_books("Broken Shelf", "some vibe", 5)
+
+            assert mock_llm.call_count == 2, (
+                f"Failure cached. LLM called {mock_llm.call_count} times, expected 2."
+            )
+            assert result1 == []
+            assert result2 == []


### PR DESCRIPTION
# Pull Request
Added `@cache_category_books` decorator to `get_category_books()` in `ai_service.py`.

## Description
Every shelf load was firing a raw LLM request. Same category = same response = wasted API quota and slow load times.
- Added `CATEGORY_BOOKS` namespace to `CacheNamespace` enum
- Added `CATEGORY_BOOKS_TTL` (12hr default, env-configurable) to `CacheConfig`  
- Added `cache_category_books` convenience decorator to `cache_service.py`
- Applied decorator to `get_category_books()` in `ai_service.py`
- Fixed bug: empty list `[]` was being cached on LLM failure (`if result is not None` → `if result`)
- Added 5 tests covering cache hit, key uniqueness, data correctness, failure handling


## Related Issue
Fixes #576 

## Type of Change
- [ ] Feature    

## Testing
All 5 pass:
- ✅ LLM called once for repeated identical inputs
- ✅ Different categories get separate cache keys
- ✅ Different counts get separate cache keys  
- ✅ Cached value matches original
- ✅ Failed responses not cached

## Screenshots
<img width="1461" height="379" alt="image" src="https://github.com/user-attachments/assets/1791ff28-0018-4846-ad9c-1b6a061d2694" />


[GSSoC'26]
