### PR TITLE
Fix: Prevent library 3D shelf wipes by enforcing SafeStorage

### DIFF
--- a/frontend/js/library-3d.js
+++ b/frontend/js/library-3d.js
@@ -252,6 +252,20 @@ const SAMPLE_BOOKS = {
         }
     ]
 };
+
+const StorageHelper = {
+    get: function(key) {
+        return typeof SafeStorage !== 'undefined' ? SafeStorage.get(key) : localStorage.getItem(key);
+    },
+    set: function(key, value) {
+        if (typeof SafeStorage !== 'undefined') {
+            SafeStorage.set(key, value);
+        } else {
+            localStorage.setItem(key, value);
+        }
+    }
+};
+
 // Action to cache or remove book from local IndexedDB
 async function toggleOfflineBook(book, buttonElement) {
     try {
@@ -326,7 +340,7 @@ class BookshelfRenderer3D {
         }
 
         const storageKey = 'bibliodrift_library';
-        return JSON.parse(localStorage.getItem(storageKey)) || {
+        return JSON.parse(StorageHelper.get(storageKey)) || {
             current: [],
             want: [],
             finished: []
@@ -1122,7 +1136,7 @@ spine.addEventListener('blur', () => this.hideTooltip());
 
         // Find current shelf for this book
         const storageKey = 'bibliodrift_library';
-        const localLibrary = JSON.parse(localStorage.getItem(storageKey)) || {};
+        const localLibrary = JSON.parse(StorageHelper.get(storageKey)) || {};
         let currentShelfForProgress = 'want';
         ['current', 'want', 'finished'].forEach(shelf => {
             const found = (localLibrary[shelf] || []).find(b => b.id === book.id || (b.volumeInfo && b.id === book.id));
@@ -1248,12 +1262,12 @@ spine.addEventListener('blur', () => this.hideTooltip());
                                 await window.libManager.updateBook(book.id, { progress: newProgress });
                             } else {
                                 // Fallback: update localStorage directly
-                                const lib = JSON.parse(localStorage.getItem('bibliodrift_library')) || {};
+                                const lib = JSON.parse(StorageHelper.get('bibliodrift_library')) || {};
                                 ['current', 'want', 'finished'].forEach(shelf => {
                                     const b = (lib[shelf] || []).find(x => x.id === book.id);
                                     if (b) b.progress = newProgress;
                                 });
-                                localStorage.setItem('bibliodrift_library', JSON.stringify(lib));
+                                StorageHelper.set('bibliodrift_library', JSON.stringify(lib));
                             }
 
                             // Update the book object in memory
@@ -1584,7 +1598,7 @@ spine.addEventListener('blur', () => this.hideTooltip());
 
         // Get existing library from localStorage
         const storageKey = 'bibliodrift_library';
-        let library = JSON.parse(localStorage.getItem(storageKey)) || {
+        let library = JSON.parse(StorageHelper.get(storageKey)) || {
             current: [],
             want: [],
             finished: []
@@ -1609,7 +1623,7 @@ spine.addEventListener('blur', () => this.hideTooltip());
             }
         });
 
-        localStorage.setItem(storageKey, JSON.stringify(library));
+        StorageHelper.set(storageKey, JSON.stringify(library));
         console.log(`Added ${book.title} to library`);
     }
 
@@ -1627,7 +1641,7 @@ spine.addEventListener('blur', () => this.hideTooltip());
         }
 
         const storageKey = 'bibliodrift_library';
-        const localLibrary = JSON.parse(localStorage.getItem(storageKey)) || {};
+        const localLibrary = JSON.parse(StorageHelper.get(storageKey)) || {};
 
         // Find existing lists
         if (!localLibrary[fromShelf]) localLibrary[fromShelf] = [];
@@ -1650,7 +1664,7 @@ spine.addEventListener('blur', () => this.hideTooltip());
         localLibrary[toShelf].push(book);
 
         // Save and refresh
-        localStorage.setItem(storageKey, JSON.stringify(localLibrary));
+        StorageHelper.set(storageKey, JSON.stringify(localLibrary));
         this.refreshShelves();
 
         // Visual Feedback (optional)
@@ -1665,7 +1679,7 @@ spine.addEventListener('blur', () => this.hideTooltip());
         }
 
         const storageKey = 'bibliodrift_library';
-        const localLibrary = JSON.parse(localStorage.getItem(storageKey)) || {};
+        const localLibrary = JSON.parse(StorageHelper.get(storageKey)) || {};
 
         let removed = false;
         ['current', 'want', 'finished'].forEach(shelf => {
@@ -1677,7 +1691,7 @@ spine.addEventListener('blur', () => this.hideTooltip());
         });
 
         if (removed) {
-            localStorage.setItem(storageKey, JSON.stringify(localLibrary));
+            StorageHelper.set(storageKey, JSON.stringify(localLibrary));
             this.refreshShelves();
             this.announceToScreenReader(`Book removed from library`);
             console.log(`Removed book ${bookId}`);
@@ -1717,7 +1731,7 @@ spine.addEventListener('blur', () => this.hideTooltip());
         });
 
         if (found) {
-            localStorage.setItem(storageKey, JSON.stringify(localLibrary));
+            StorageHelper.set(storageKey, JSON.stringify(localLibrary));
             this.refreshShelves();
         }
     }
@@ -1746,7 +1760,7 @@ spine.addEventListener('blur', () => this.hideTooltip());
         
         // Gather all books
         const storageKey = 'bibliodrift_library';
-        const localLibrary = JSON.parse(localStorage.getItem(storageKey)) || {
+        const localLibrary = JSON.parse(StorageHelper.get(storageKey)) || {
             current: [],
             want: [],
             finished: []


### PR DESCRIPTION
Resolves #501

**Description:**
This PR fixes a bug where `library-3d.js` bypassed `LibraryManager` and directly read/wrote to raw `localStorage`. This caused shelves to appear empty if the browser's `localStorage` was cleared, even if the data was successfully backed up in IndexedDB or on the backend.

**Changes:**
- Introduced a lightweight `StorageHelper` in `library-3d.js`.
- Replaced all direct `localStorage.getItem` and `localStorage.setItem` calls with `StorageHelper.get` and `StorageHelper.set`.
- Ensures the 3D library correctly utilizes the `SafeStorage` wrapper (with its IndexedDB fallback mechanics) when available, while gracefully falling back to native `localStorage` if necessary.
