### PR TITLE
Fix: handle varying AI JSON shapes in fetchAIVibe (#502)

### DIFF
--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -702,7 +702,8 @@ scene.innerHTML = `
             });
             if (res.ok) {
                 const data = await res.json();
-                return data.data?.vibe || null;
+                const payload = data.data || data;
+                return payload?.vibe || payload?.bookseller_note || payload?.insight || payload?.note || null;
             }
         } catch (e) {
             // Silently fail to use fallback


### PR DESCRIPTION
Resolves #502

**Description:**
The backend `generate-note` endpoint occasionally returns AI insights under alternative keys (e.g., `bookseller_note`, `insight`) rather than the strictly expected `vibe` key. This caused the frontend to silently drop perfectly valid AI blurbs.

**Changes:**
- Updated the parsing logic in `app.js` -> `fetchAIVibe` to safely unwrap the `data` object.
- Added a fallback chain checking `vibe`, `bookseller_note`, `insight`, and `note` before defaulting to `null`.
