### PR TITLE
Fix: Toggle search results section without replacing main innerHTML (#503)

### DIFF
--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -1942,16 +1942,19 @@ document.addEventListener('DOMContentLoaded', async () => {
         searchInput.value = query;
     }
 
-    if (query && document.getElementById('row-rainy')) {
-        document.querySelector('main').innerHTML = `
-            <section class="hero">
-                <h1>Results for "${query}"</h1>
-                <p>Found specific books matching your vibe.</p>
-            </section>
-            <section class="curated-section">
-                <div class="curated-row" id="search-results" style="flex-wrap: wrap; justify-content: center;"></div>
-            </section>`;
-        renderer.renderCuratedSection(query, 'search-results', 20);
+    if (query && document.getElementById('search-results-section')) {
+        const searchSection = document.getElementById('search-results-section');
+        const queryDisplay = document.getElementById('search-query-display');
+        
+        queryDisplay.textContent = `Results for "${query}"`;
+        searchSection.removeAttribute('hidden');
+        
+        // Hide other main content to focus on search without destroying modals
+        document.querySelectorAll('.curated-section:not(#search-results-section), .hero').forEach(el => {
+            el.style.display = 'none';
+        });
+
+        renderer.renderCuratedSection(query, 'search-results-grid', 20);
     } else if (document.getElementById('row-rainy')) {
         console.log('📚 Initializing Curated Discovery Sections...');
         const discoveryShelves = [


### PR DESCRIPTION
Resolves #503.

**Changes:**
- Refactored the search rendering logic in `app.js` to utilize the pre-existing `#search-results-section` and `#search-results-grid` instead of replacing `main.innerHTML`.
- Hides other `.curated-section` elements and the `.hero` section during a search to maintain layout focus.
- Prevents the destruction of other critical elements inside `<main>`, specifically fixing the bug where the `#book-details-modal` failed to open on search results because it was deleted from the DOM.
