### PR TITLE
Fix: prevent duplicate ESC keydown listeners on modal open (#504)

### DIFF
--- a/frontend/js/library-3d.js
+++ b/frontend/js/library-3d.js
@@ -292,8 +292,6 @@ class BookshelfRenderer3D {
         this.cleanupCallbacks = [];
         this.isDestroyed = false;
         this._modalBackdropHandler = null;
-        this._escHandler = null;
-        this._escListenerAttached = false;
 
         // Create live region for screen reader announcements
         this.liveRegion = document.createElement('div');
@@ -429,6 +427,13 @@ class BookshelfRenderer3D {
         });
         this.addManagedListener(window, 'bibliodrift:library-manager-synced', () => {
             this.refreshShelves();
+        });
+
+        // Attach global ESC listener for modal exactly once
+        this.addManagedListener(document, 'keydown', (e) => {
+            if (e.key === 'Escape' && this.modal && this.modal.classList.contains('active')) {
+                this.closeModal();
+            }
         });
 
         // Setup modal close handlers
@@ -1426,7 +1431,6 @@ spine.addEventListener('blur', () => this.hideTooltip());
         if (this.modal) {
             this.modal.classList.remove('active');
             document.body.style.overflow = '';
-            this.removeEscListener();
 
             // Reset flip after transition
             setTimeout(() => {
@@ -1438,14 +1442,6 @@ spine.addEventListener('blur', () => this.hideTooltip());
                 fixedControls.forEach(el => el.style.opacity = '1');
                 fixedControls.forEach(el => el.style.pointerEvents = 'auto');
             }, 500);
-        }
-    }
-
-    removeEscListener() {
-        if (this._escHandler && this._escListenerAttached) {
-            document.removeEventListener('keydown', this._escHandler);
-            this._escListenerAttached = false;
-            this._escHandler = null;
         }
     }
 
@@ -1497,17 +1493,6 @@ spine.addEventListener('blur', () => this.hideTooltip());
                 }
             };
             this.addManagedListener(this.modal, 'click', this._modalBackdropHandler);
-        }
-
-        // ESC key to close - attach only once, remove on close
-        if (!this._escListenerAttached) {
-            this._escHandler = (e) => {
-                if (e.key === 'Escape' && this.modal && this.modal.classList.contains('active')) {
-                    this.closeModal();
-                }
-            };
-            document.addEventListener('keydown', this._escHandler);
-            this._escListenerAttached = true;
         }
 
         // Add to library button logic


### PR DESCRIPTION
Resolves #504.

**The Issue:**
The `Escape` keydown listener was being re-evaluated every time the book details modal was opened via `setupModalHandlers()`. While an earlier fix added a state flag (`_escListenerAttached`) and detach logic, this tracking was prone to desync and caused unnecessary attach/detach cycles.

**The Fix:**
- Moved the `Escape` listener registration from `setupModalHandlers()` to the `init()` method so it binds exactly once per instance.
- Safely bound the listener to the `document` using `addManagedListener` to ensure proper garbage collection during component teardown.
- Removed legacy state tracking variables and the `removeEscListener` method, keeping the implementation minimal and clean.
