### PR TITLE
Fix: mitigate XSS by building DOM nodes instead of using innerHTML (#505)

### DIFF
--- a/frontend/js/chat.js
+++ b/frontend/js/chat.js
@@ -413,6 +413,42 @@ Tell me: what is stirring in you today?`,
     }
 
     /**
+     * Build DOM nodes for lightweight markdown.
+     * Supports: **bold** for book titles, *italic* for authors, \n for line breaks.
+     * @param {HTMLElement} container - The container element
+     * @param {string} text - The raw message text
+     */
+    buildMarkdownNodes(container, text) {
+        const regex = /\*\*(.+?)\*\*|\*(.+?)\*|(\n)/g;
+        let lastIndex = 0;
+        let match;
+
+        while ((match = regex.exec(text)) !== null) {
+            if (match.index > lastIndex) {
+                container.appendChild(document.createTextNode(text.substring(lastIndex, match.index)));
+            }
+
+            if (match[1]) {
+                const strong = document.createElement('strong');
+                strong.textContent = match[1];
+                container.appendChild(strong);
+            } else if (match[2]) {
+                const em = document.createElement('em');
+                em.textContent = match[2];
+                container.appendChild(em);
+            } else if (match[3]) {
+                container.appendChild(document.createElement('br'));
+            }
+
+            lastIndex = regex.lastIndex;
+        }
+
+        if (lastIndex < text.length) {
+            container.appendChild(document.createTextNode(text.substring(lastIndex)));
+        }
+    }
+
+    /**
      * Render lightweight markdown in AI responses.
      * Supports: **bold** for book titles, *italic* for authors, \n\n for paragraphs.
      * Uses textContent assignment (not innerHTML) for user messages to prevent XSS.
@@ -426,18 +462,7 @@ Tell me: what is stirring in you today?`,
             if (!paragraph.trim()) return;
             const p = document.createElement('p');
             if (isAI) {
-                // Apply markdown replacements then sanitize with DOMPurify
-                let content = paragraph.trim()
-                    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
-                    .replace(/\*(.+?)\*/g, '<em>$1</em>')
-                    .replace(/\n/g, '<br>');
-                
-                // Sanitize HTML to prevent XSS attacks
-                p.innerHTML = DOMPurify.sanitize(content, {
-                    ALLOWED_TAGS: ['strong', 'em', 'br', 'b', 'i', 'u'],
-                    ALLOWED_ATTR: [],
-                    KEEP_CONTENT: true
-                });
+                this.buildMarkdownNodes(p, paragraph.trim());
             } else {
                 p.textContent = paragraph.trim();
             }


### PR DESCRIPTION
Resolves #505

**Summary:**
This PR addresses potential XSS vulnerabilities in the chat interface by eliminating `innerHTML` injection for AI responses.

**Changes:**
- Added a `buildMarkdownNodes` helper to tokenize lightweight markdown (`**bold**`, `*italic*`, `\n`) and safely render them using native `document.createElement` and `document.createTextNode`.
- Updated `renderTextContent` to use the new node builder instead of `innerHTML` and `DOMPurify`.

**Why:**
Manually constructing text and element nodes ensures that any unexpected HTML returned by the backend or proxy is strictly treated as text by the browser, providing robust XSS defense without relying on third-party sanitization libraries.
