### PR TITLE
fix: add dark mode styles for privacy and terms pages (#375)

### DIFF
--- a/frontend/pages/privacy-policy.html
+++ b/frontend/pages/privacy-policy.html
@@ -18,6 +18,17 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,600&family=Georgia&display=swap" rel="stylesheet" />
+  <style>
+  [data-theme="night"] main h2 {
+    color: var(--text-primary, #e8d5b7);
+  }
+  [data-theme="night"] main p {
+    color: var(--text-muted, #b8a898);
+  }
+  [data-theme="night"] main {
+    color: var(--text-primary, #e8d5b7);
+  }
+</style>
 </head>
 
 <body>

--- a/frontend/pages/terms-and-conditions.html
+++ b/frontend/pages/terms-and-conditions.html
@@ -18,6 +18,17 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,600&family=Georgia&display=swap" rel="stylesheet" />
+  <style>
+  [data-theme="night"] main h2 {
+    color: var(--text-primary, #e8d5b7);
+  }
+  [data-theme="night"] main p {
+    color: var(--text-muted, #b8a898);
+  }
+  [data-theme="night"] main {
+    color: var(--text-primary, #e8d5b7);
+  }
+</style>
 </head>
 
 <body>


### PR DESCRIPTION
Fixes #375

## What changed
Added dark mode CSS styles for h2 headings and paragraphs 
on privacy-policy.html and terms-and-conditions.html pages.

## Why
In night mode, headings were invisible (black text on dark background).

## How to test
1. Open privacy-policy.html in browser
2. Toggle dark mode
3. Headings now visible ✓