### PR TITLE
 [GSSoC'26] Improve mobile responsiveness and layout balance for Library page

### DIFF
--- a/frontend/css/style-responsive.css
+++ b/frontend/css/style-responsive.css
@@ -4,6 +4,7 @@
 :root {
     --book-width: 180px;
     --book-height: 280px;
+}
 /* Universal Mobile-First Improvements */
 * {
     -webkit-tap-highlight-color: transparent;
@@ -422,12 +423,15 @@ button, a, input {
         padding: 2px 1px;
     }
 }
+}
+
 
 /* --- Tablet to Phone Transition (600px) --- */
 @media (max-width: 600px) {
     :root {
         --book-width: 110px;
         --book-height: 170px;
+    }
 
     .spine-author {
         font-size: 0.5rem;
@@ -539,48 +543,93 @@ button, a, input {
 
 /* --- Library Page Specific Adjustments --- */
 @media (max-width: 768px) {
-    .library-hero {
-        padding: 1.5rem 1rem;
+    body.library-page .library-hero {
+        padding: 1.25rem 1rem;
     }
 
-    .library-hero h1 {
-        font-size: 2rem;
+    body.library-page .library-hero h1 {
+        font-size: clamp(1.7rem, 5vw, 2rem);
+        line-height: 1.1;
     }
 
-    .hero .view-toggles {
+    body.library-page .library-hero p {
+        max-width: 28rem;
+        margin-inline: auto;
+    }
+
+    body.library-page .hero .view-toggles {
         margin-top: 1rem !important;
         gap: 0.75rem !important;
+        flex-wrap: wrap;
     }
 
-    .view-toggles button {
+    body.library-page .view-toggles button {
+        flex: 1 1 11rem;
+        min-width: 9rem;
         padding: 0.5rem 1rem !important;
         font-size: 0.9rem;
     }
 
-    #export-library {
+    body.library-page #export-library {
         position: static !important;
-        width: auto;
+        width: min(100%, 20rem);
         max-width: 100%;
-        margin: 0.5rem 0 !important;
+        margin: 0.5rem auto 0 !important;
     }
 
-    .sort-controls {
+    body.library-page .sort-controls {
         flex-direction: column;
         gap: 0.8rem;
         padding: 1rem 0.5rem;
         width: 100%;
     }
 
-    .filter-group {
+    body.library-page .filter-group {
         width: 100%;
         padding: 0.75rem;
         gap: 0.5rem;
     }
 
-    .sort-select {
+    body.library-page .sort-select {
         width: 100%;
         padding: 0.5rem;
         font-size: 0.9rem;
+    }
+}
+
+@media (max-width: 480px) {
+    body.library-page .library-hero {
+        padding: 1rem 0.75rem;
+    }
+
+    body.library-page .library-hero h1 {
+        font-size: 1.55rem;
+    }
+
+    body.library-page .library-hero p {
+        font-size: 0.95rem;
+    }
+
+    body.library-page .hero .view-toggles {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    body.library-page .view-toggles button {
+        width: 100%;
+        min-width: 0;
+    }
+
+    body.library-page #export-library {
+        width: 100%;
+    }
+
+    body.library-page .filter-group {
+        flex-wrap: wrap;
+    }
+
+    body.library-page .filter-group i {
+        flex: 0 0 auto;
     }
 }
 
@@ -1030,6 +1079,7 @@ button, a, input {
         width: 96vw;
         max-height: 85vh;
     }
+}
 
 /* Style the container for controls */
 .sort-controls {

--- a/frontend/pages/library.html
+++ b/frontend/pages/library.html
@@ -39,7 +39,7 @@
     <script src="https://d3js.org/d3.v7.min.js"></script>
 </head>
 
-<body>
+<body class="library-page">
 
     <header>
         <a href="index.html" class="logo">
@@ -91,7 +91,6 @@
                     <i class="fa-solid fa-chart-nodes"></i> Constellation
                 </button>
             </div>
-            <div class="sort-controls">
             <div class="sort-controls" role="region" aria-label="Library filter and sort controls">
                 <div class="filter-group">
                     <i class="fa-solid fa-filter"></i>


### PR DESCRIPTION
# Pull Request

## Description

[GSSoC'26] Improved the mobile responsiveness and visual balance of the Library page layout.

### Changes Made

* Reduced excessive vertical spacing in the mobile header/navigation section
* Improved alignment and structure of navigation elements
* Optimized spacing between navbar and hero section
* Fixed responsive overflow issue in the view toggle buttons
* Refined mobile layout for filters and controls
* Improved overall visual consistency while maintaining the existing UI theme

## Related Issue

Fixes #618 
Reference: #618 

## Type of Change

* [x] Bug Fix
* [ ] Feature
* [x] Enhancement
* [ ] Documentation

## Testing

* Tested on responsive mobile viewports using browser developer tools
* Verified layout consistency at multiple mobile widths
* Confirmed that toggle buttons no longer overflow on smaller screens
* Checked responsiveness and spacing alignment across sections

## Screenshots

### Before
<img width="1000" height="595" alt="b11" src="https://github.com/user-attachments/assets/ad7c3e17-1f16-4c12-ac3c-5215fbf75ac7" />


### After

<img width="955" height="590" alt="b22" src="https://github.com/user-attachments/assets/5639b131-1bc0-4164-810f-69b3c1f930f2" />


## Checklist

* [x] Code follows guidelines
* [x] Tested properly
* [ ] Docs updated
* [x] PR title includes the relevant event tag or a general contribution label

> Note: This PR only focuses on improving the mobile responsiveness and spacing/alignment issues of the Library page. It does not overlap with or modify any functionality related to Issue #599.
