### PR TITLE
Fixed Duplicate Sign In/ Create One button Issue

### DIFF
--- a/frontend/pages/auth.html
+++ b/frontend/pages/auth.html
@@ -366,13 +366,13 @@
                     <button type="submit" id="submitBtn" class="auth-btn">
                         Sign In
                     </button>
-                </form>
 
-                <div class="auth-footer">
-                    <span id="toggleText" class="toggle-link">
-                        No account? Create one.
-                    </span>
-                </div>
+                    <div class="auth-footer">
+                        <span id="toggleText" class="toggle-link">
+                            No account? Create one.
+                        </span>
+                    </div>
+                </form>
                 
                 <!-- 
                     =============================================================
@@ -386,19 +386,7 @@
                     =============================================================
                 -->
                 <input type="hidden" id="csrf_token" name="csrf_token" value="">
-                
-                <!-- Primary Action Button -->
-                <button type="submit" id="submitBtn" class="auth-btn">
-                    Sign In
-                </button>
-            </form>
-            
-            <!-- Mode Toggle Link -->
-            <div class="auth-footer" style="margin-top: 1.5rem;">
-                <span id="toggleText" class="toggle-link">
-                    No account? Create one.
-                </span>
-            </div>
+
         </section>
     </main>
 


### PR DESCRIPTION
# Pull Request

## Title

[GSSoC'26] Fix duplicate authentication buttons and links on auth pages

## Description

Fixed the issue where the Sign In button and authentication toggle links were rendering twice on both Sign In and Sign Up pages.

### Changes Made

* Removed duplicate Sign In button
* Removed duplicate auth footer/toggle link
* Removed extra closing form tag
* Cleaned and corrected HTML structure
* Fixed duplicate element IDs issue

## Related Issue

Fixes #634 

## Type of Change

* [x] Bug Fix
* [ ] Feature
* [ ] Enhancement
* [ ] Documentation

## Testing

* Tested Sign In page functionality
* Tested Sign Up page functionality
* Verified only one button and one toggle link appear
* Checked form switching behavior works correctly

## Screenshots

Before:

<img width="1365" height="767" alt="Screenshot 2026-05-17 143443" src="https://github.com/user-attachments/assets/60a48de4-359c-46e3-b4bf-848399842bc3" />
<img width="1365" height="767" alt="Screenshot 2026-05-17 143418" src="https://github.com/user-attachments/assets/81c38135-f4e6-462a-95ef-ac2842bce247" />


After:

<img width="1365" height="679" alt="image" src="https://github.com/user-attachments/assets/12241379-a0ae-4607-840b-228c07b8af5b" />
<img width="1364" height="687" alt="image" src="https://github.com/user-attachments/assets/b9c0212e-4e44-4792-be41-e4d73e6dbe98" />

## Checklist

* [x] Code follows guidelines
* [x] Tested properly
* [ ] Docs updated
* [x] PR title includes the relevant event tag or a general contribution label
