### PR TITLE
Feat: Expose Purchase Links API & "Where to Buy" detail modal section (#645)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -600,6 +600,30 @@ def handle_category_books():
         logger.error(f"Error in handle_category_books: {str(e)}", exc_info=True)
         return internal_error(str(e))
 
+
+@app.route('/api/v1/books/purchase-links', methods=['GET'])
+@rate_limit('purchase_links')
+def handle_purchase_links():
+    """Get purchase links for a book."""
+    try:
+        title = request.args.get('title')
+        author = request.args.get('author', '')
+        isbn = request.args.get('isbn', '')
+        
+        if not title:
+            return jsonify({'success': False, 'error': 'Title is required'}), 400
+            
+        from purchase_links import PurchaseManager
+        manager = PurchaseManager()
+        
+        links = manager.get_quick_links(title=title, author=author, isbn=isbn)
+        
+        return success_response(data={"links": links})
+        
+    except Exception as e:
+        logger.error(f"Error getting purchase links: {str(e)}", exc_info=True)
+        return internal_error(str(e))
+
 @app.route('/api/v1/generate-note', methods=['POST'])
 @rate_limit('generate_note')
 def handle_generate_note():

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -838,6 +838,39 @@ class BookRenderer {
             };
         }
 
+        // Fetch and render purchase links
+        const purchaseLinksEl = document.getElementById('modal-purchase-links');
+        if (purchaseLinksEl) {
+            purchaseLinksEl.innerHTML = '<div class="text-skeleton skeleton" style="width: 100%; height: 30px;"></div>';
+            
+            const title = encodeURIComponent(book.volumeInfo.title || '');
+            const author = encodeURIComponent(book.volumeInfo.authors ? book.volumeInfo.authors[0] : '');
+            let isbn = '';
+            if (book.volumeInfo.industryIdentifiers) {
+                const identifier = book.volumeInfo.industryIdentifiers.find(i => i.type === 'ISBN_13' || i.type === 'ISBN_10');
+                if (identifier) isbn = encodeURIComponent(identifier.identifier);
+            }
+            
+            fetch(`${MOOD_API_BASE}/books/purchase-links?title=${title}&author=${author}&isbn=${isbn}`)
+                .then(res => res.json())
+                .then(data => {
+                    if (data.success && data.links && data.links.length > 0) {
+                        const linksHtml = data.links.map(link => {
+                            return `<a href="${link.url}" target="_blank" class="purchase-link-btn" style="background-color: ${link.color || 'var(--wood-dark)'}; color: white; padding: 5px 10px; border-radius: 5px; text-decoration: none; display: inline-flex; align-items: center; gap: 5px; margin-right: 5px; margin-bottom: 5px; font-size: 0.85rem;">
+                                <i class="${link.icon || 'fa-solid fa-book'}"></i> ${link.name}
+                            </a>`;
+                        }).join('');
+                        purchaseLinksEl.innerHTML = linksHtml;
+                    } else {
+                        purchaseLinksEl.innerHTML = '<p class="modal-subtitle" style="margin: 0; font-size: 0.85rem; opacity: 0.7;">No purchase links available.</p>';
+                    }
+                })
+                .catch(err => {
+                    console.error('Failed to load purchase links', err);
+                    purchaseLinksEl.innerHTML = '<p class="modal-subtitle" style="margin: 0; font-size: 0.85rem; opacity: 0.7;">Failed to load purchase links.</p>';
+                });
+        }
+
         modal.showModal();
         document.getElementById('closeModalBtn').onclick = () => modal.close();
 

--- a/frontend/js/library-3d.js
+++ b/frontend/js/library-3d.js
@@ -540,10 +540,16 @@ class BookshelfRenderer3D {
         books = books.map(b => {
             // If it's already flat (like sample), keep it. If it's Google Books style (volumeInfo), flatten it.
             if (b.volumeInfo) {
+                let isbnVal = '';
+                if (b.volumeInfo.industryIdentifiers) {
+                    const identifier = b.volumeInfo.industryIdentifiers.find(i => i.type === 'ISBN_13' || i.type === 'ISBN_10');
+                    if (identifier) isbnVal = identifier.identifier;
+                }
                 return {
                     id: b.id,
                     title: b.volumeInfo.title || 'Untitled',
                     author: (b.volumeInfo.authors && b.volumeInfo.authors[0]) || 'Unknown',
+                    isbn: isbnVal,
                     cover: b.volumeInfo.imageLinks?.thumbnail || '',
                     description: b.volumeInfo.description || '',
                     rating: b.volumeInfo.averageRating || 4.0,
@@ -1424,6 +1430,35 @@ spine.addEventListener('blur', () => this.hideTooltip());
                     window.BookPreview.open(book.id, book.title || 'Book Preview');
                 }
             });
+        }
+
+        // Fetch and render purchase links
+        const purchaseLinksEl = document.getElementById('modal-purchase-links-lib');
+        if (purchaseLinksEl) {
+            purchaseLinksEl.innerHTML = '<div class="text-skeleton skeleton" style="width: 100%; height: 30px;"></div>';
+            
+            const title = encodeURIComponent(book.title || '');
+            const author = encodeURIComponent(book.author || '');
+            const isbn = encodeURIComponent(book.isbn || '');
+            
+            fetch(`${MOOD_API_BASE}/books/purchase-links?title=${title}&author=${author}&isbn=${isbn}`)
+                .then(res => res.json())
+                .then(data => {
+                    if (data.success && data.links && data.links.length > 0) {
+                        const linksHtml = data.links.map(link => {
+                            return `<a href="${link.url}" target="_blank" class="purchase-link-btn" style="background-color: ${link.color || 'var(--wood-dark)'}; color: white; padding: 5px 10px; border-radius: 5px; text-decoration: none; display: inline-flex; align-items: center; gap: 5px; margin-right: 5px; margin-bottom: 5px; font-size: 0.85rem;">
+                                <i class="${link.icon || 'fa-solid fa-book'}"></i> ${link.name}
+                            </a>`;
+                        }).join('');
+                        purchaseLinksEl.innerHTML = linksHtml;
+                    } else {
+                        purchaseLinksEl.innerHTML = '<p class="modal-subtitle" style="margin: 0; font-size: 0.85rem; opacity: 0.7;">No purchase links available.</p>';
+                    }
+                })
+                .catch(err => {
+                    console.error('Failed to load purchase links', err);
+                    purchaseLinksEl.innerHTML = '<p class="modal-subtitle" style="margin: 0; font-size: 0.85rem; opacity: 0.7;">Failed to load purchase links.</p>';
+                });
         }
 
         // Show modal and manage focus

--- a/frontend/pages/index.html
+++ b/frontend/pages/index.html
@@ -190,6 +190,13 @@
                 <div class="text-skeleton skeleton" style="width: 70%"></div>
               </div>
             </div>
+            <!-- Added "Where to Buy" section -->
+            <div class="purchase-links-box" style="margin-top: 15px;">
+              <div class="purchase-header"><i class="fa-solid fa-cart-shopping"></i><span> Where to Buy</span></div>
+              <div id="modal-purchase-links" class="purchase-links-container">
+                <div class="text-skeleton skeleton"></div>
+              </div>
+            </div>
             <div class="modal-actions">
               <button id="modal-add-btn" class="btn-primary"><i class="fa-regular fa-heart"></i> Add to Library</button>
               <button id="modal-preview-btn" class="btn-preview"><i class="fa-solid fa-book-open"></i> Preview</button>

--- a/frontend/pages/library.html
+++ b/frontend/pages/library.html
@@ -298,6 +298,18 @@
                             </div>
                         </div>
 
+                        <!-- Where to Buy section -->
+                        <div class="purchase-links-box" style="margin-bottom: 1.5rem;">
+                            <div class="purchase-header"
+                                style="display: flex; align-items: center; gap: 8px; margin-bottom: 10px; color: var(--accent-gold); font-size: 0.9rem; font-weight: 600;">
+                                <i class="fa-solid fa-cart-shopping"></i>
+                                <span>Where to Buy</span>
+                            </div>
+                            <div id="modal-purchase-links-lib" class="purchase-links-container" style="display: flex; flex-wrap: wrap; gap: 8px;">
+                                <div class="text-skeleton skeleton" style="width: 100%; height: 30px;"></div>
+                            </div>
+                        </div>
+
                         <div class="book-actions-section">
                             <div class="library-actions-group">
                                 <!-- Issue #23: Remove from Library button UI -->

--- a/tests/test_purchase_links.py
+++ b/tests/test_purchase_links.py
@@ -1,0 +1,50 @@
+import pytest
+import json
+import sys
+import os
+from unittest.mock import patch
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'backend'))
+from app import app
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+def test_purchase_links_missing_title(client):
+    """Test purchase-links endpoint with missing title parameter."""
+    response = client.get('/api/v1/books/purchase-links')
+    assert response.status_code == 400
+    data = json.loads(response.data)
+    assert data['success'] is False
+    assert 'error' in data
+    assert data['error'] == 'Title is required'
+
+@patch('purchase_links.purchase_manager.PurchaseManager.get_quick_links')
+def test_purchase_links_success(mock_get_quick_links, client):
+    """Test purchase-links endpoint with valid parameters and mocked manager."""
+    mock_get_quick_links.return_value = [
+        {
+            'platform': 'google_books',
+            'name': 'Google Books',
+            'url': 'https://books.google.com/books?id=zyTCAlFPjgYC',
+            'available': True,
+            'color': '#EA4335',
+            'icon': 'fa-solid fa-book'
+        }
+    ]
+    
+    response = client.get('/api/v1/books/purchase-links?title=Dune&author=Frank+Herbert&isbn=9780441172719')
+    data = json.loads(response.data)
+    print("RESPONSE DATA:", data)
+    assert response.status_code == 200
+    assert data['success'] is True
+    assert 'links' in data
+    
+    links = data['links']
+    assert len(links) == 1
+    assert links[0]['name'] == 'Google Books'
+    assert links[0]['url'] == 'https://books.google.com/books?id=zyTCAlFPjgYC'
+    assert links[0]['color'] == '#EA4335'
+    assert links[0]['icon'] == 'fa-solid fa-book'


### PR DESCRIPTION
## Overview
This PR implements secure server-side fetching and dynamic client-side rendering of book purchase links, addressing issue #645. It exposes purchase platforms (Google Books, Barnes & Noble, Amazon, and Flipkart) while keeping credentials and affiliate ids confidential on the backend.

## Key Changes
- **Backend Route**: Registered `GET /api/v1/books/purchase-links` in `backend/app.py` protected by rate-limiting. Exposes dynamic retailer URLs formatted using existing `PurchaseManager` logic.
- **Frontend Templates**: Injected matching premium skeleton structures (`#modal-purchase-links` and `#modal-purchase-links-lib`) into detail modals in `index.html` and `library.html`.
- **Dynamic Adaption**: Refactored `app.js` and `library-3d.js` modal loaders to asynchronously fetch and map affiliate tags dynamically using branding colors/icons. Preserves the ISBN identifier through shelf-mapping.
- **Testing**: Added clean pytest integrations in `tests/test_purchase_links.py` ensuring security envelopes and validation boundaries function reliably.

### Closes #645 