### PR TITLE
Fix frontend regressions — CSS syntax, script order & module mismatch

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -4670,3 +4670,123 @@ html, body {
   cursor: pointer !important; 
   cursor: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 24 24'><path fill='%23ffca3a' d='M4.42 20.58a1 1 0 0 0 1.41 0L15.24 11.2l-2.44-2.44L3.42 18.17a1 1 0 0 0 0 1.41zM17.36 9.08l-2.44-2.44 2.12-2.12a2 2 0 0 1 2.83 0l1.77 1.77a2 2 0 0 1 0 2.83z'/><path stroke='%23ffca3a' stroke-width='1.5' d='M2 22l4-1'/></svg>") 0 24, pointer !important;
 }
+
+/* Mood-Tag Filter Bar for Discovery Search Results */
+.mood-filter-bar {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin: 1.5rem 1rem 2rem 1rem;
+    padding: 0.8rem 1.2rem;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 12px;
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    animation: fadeIn 0.5s ease-out;
+}
+
+[data-theme="night"] .mood-filter-bar {
+    background: rgba(0, 0, 0, 0.25);
+    border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.filter-label {
+    font-family: 'Playfair Display', serif;
+    font-size: 1rem;
+    color: var(--text-muted);
+    font-style: italic;
+    white-space: nowrap;
+}
+
+.filter-chips {
+    display: flex;
+    gap: 0.8rem;
+    overflow-x: auto;
+    scrollbar-width: none; /* Hide scrollbar for clean look */
+    -ms-overflow-style: none;
+    padding: 2px 0;
+    width: 100%;
+}
+
+.filter-chips::-webkit-scrollbar {
+    display: none; /* Hide scrollbar in chrome/safari */
+}
+
+.filter-chip {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 14px;
+    background: rgba(0, 0, 0, 0.05);
+    border: 1px solid rgba(0, 0, 0, 0.08);
+    border-radius: 20px;
+    color: var(--text-main);
+    font-size: 0.85rem;
+    font-family: "Georgia", serif;
+    cursor: pointer;
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    white-space: nowrap;
+    user-select: none;
+}
+
+[data-theme="night"] .filter-chip {
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.filter-chip:hover {
+    transform: translateY(-2px);
+    background: rgba(0, 0, 0, 0.1);
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.08);
+}
+
+[data-theme="night"] .filter-chip:hover {
+    background: rgba(255, 255, 255, 0.1);
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+}
+
+.filter-chip.active {
+    background: var(--accent-gold) !important;
+    border-color: var(--accent-gold) !important;
+    color: #2c2420 !important;
+    font-weight: 600;
+    box-shadow: 0 4px 12px rgba(212, 175, 55, 0.4);
+}
+
+.filter-chip i {
+    font-size: 0.8rem;
+    transition: transform 0.3s ease;
+}
+
+.filter-chip.active i {
+    transform: scale(1.15);
+}
+
+/* Empty filter matches state styling */
+.empty-filter-state {
+    grid-column: 1 / -1;
+    text-align: center;
+    padding: 4rem 2rem;
+    color: var(--text-muted);
+    font-family: 'Playfair Display', serif;
+    animation: fadeIn 0.4s ease-out;
+}
+
+.empty-filter-state i {
+    font-size: 3rem;
+    color: var(--accent-gold);
+    margin-bottom: 1rem;
+    display: block;
+}
+
+.empty-filter-state h3 {
+    font-size: 1.5rem;
+    margin-bottom: 0.5rem;
+    color: var(--text-main);
+}
+
+.empty-filter-state p {
+    font-size: 1rem;
+    opacity: 0.8;
+}

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -726,6 +726,26 @@ class BookRenderer {
         return null;
     }
 
+    async fetchMoodTags(title, author) {
+        try {
+            const csrfToken = getCookie('csrf_access_token');
+            const headers = { 'Content-Type': 'application/json' };
+            if (csrfToken) {
+                headers['X-CSRF-TOKEN'] = csrfToken;
+            }
+            const res = await fetch(`${MOOD_API_BASE}/mood-tags`, {
+                method: 'POST',
+                headers: headers,
+                credentials: 'include',
+                body: JSON.stringify({ title, author })
+            });
+            return res;
+        } catch (e) {
+            console.error("fetchMoodTags error", e);
+            return null;
+        }
+    }
+
     generateVibe(text, categories = []) {
         // Fallback vibes if AI hasn't loaded yet.
         const lowerText = text.toLowerCase();
@@ -896,13 +916,40 @@ class BookRenderer {
 
     getMoodIcon(mood) {
         const icons = {
+            'melancholic': 'fa-cloud-showers-heavy',
+            'melancholy': 'fa-cloud-showers-heavy',
+            'cozy': 'fa-mug-hot',
+            'tense': 'fa-bolt',
+            'intense': 'fa-bolt',
+            'inspiring': 'fa-lightbulb',
+            'uplifting': 'fa-lightbulb',
+            'whimsical': 'fa-wand-magic-sparkles',
+            'dark': 'fa-moon',
+            'adventurous': 'fa-compass',
+            'mysterious': 'fa-eye',
+            'romantic': 'fa-heart',
+            'atmospheric': 'fa-wind',
+            'thoughtful': 'fa-brain',
+            'thought-provoking': 'fa-brain',
+            'emotional': 'fa-face-sad-tear',
+            
+            // Capitalized versions
             'Melancholic': 'fa-cloud-showers-heavy',
+            'Melancholy': 'fa-cloud-showers-heavy',
             'Cozy': 'fa-mug-hot',
             'Tense': 'fa-bolt',
+            'Intense': 'fa-bolt',
             'Inspiring': 'fa-lightbulb',
+            'Uplifting': 'fa-lightbulb',
             'Whimsical': 'fa-wand-magic-sparkles',
             'Dark': 'fa-moon',
-            'Adventurous': 'fa-compass'
+            'Adventurous': 'fa-compass',
+            'Mysterious': 'fa-eye',
+            'Romantic': 'fa-heart',
+            'Atmospheric': 'fa-wind',
+            'Thoughtful': 'fa-brain',
+            'Thought-provoking': 'fa-brain',
+            'Emotional': 'fa-face-sad-tear'
         };
         return icons[mood] || 'fa-tag';
     }
@@ -1040,6 +1087,11 @@ class BookRenderer {
     }
 
     async renderBookCards(container, books) {
+        if (container.id === 'search-results-grid') {
+            window.searchFilterManager = new SearchFilterManager(container, books, this);
+            return;
+        }
+
         container.innerHTML = '';
         if (!books || books.length === 0) {
             container.innerHTML = '<p class="empty-state">No books available for this collection.</p>';
@@ -1061,6 +1113,257 @@ class BookRenderer {
         // If nothing was rendered, show error
         if (container.children.length === 0) {
             container.innerHTML = '<p class="empty-state">Failed to load books. Please check your connection.</p>';
+        }
+    }
+}
+
+class SearchFilterManager {
+    constructor(container, books, renderer) {
+        this.container = container;
+        this.books = books;
+        this.renderer = renderer;
+        this.activeFilter = null;
+        this.uniqueMoods = new Set();
+        this.bookElements = new Map(); // bookId -> bookSceneElement
+
+        // Initialize UI elements
+        this.filterBar = document.getElementById('mood-filter-bar');
+        this.chipsContainer = document.getElementById('filter-chips');
+        
+        if (this.filterBar && this.chipsContainer) {
+            this.filterBar.hidden = false;
+            this.chipsContainer.innerHTML = '';
+        }
+
+        // Restore active filter from URL query params or sessionStorage if exists
+        const urlParams = new URLSearchParams(window.location.search);
+        this.activeFilter = urlParams.get('mood') || sessionStorage.getItem('active_mood_filter');
+
+        this.init();
+    }
+
+    async init() {
+        // Clear previous grid
+        this.container.innerHTML = '';
+        
+        // Render all books first
+        for (const book of this.books) {
+            try {
+                const bookElement = await this.renderer.createBookElement(book);
+                if (bookElement) {
+                    this.container.appendChild(bookElement);
+                    this.bookElements.set(book.id, bookElement);
+                }
+            } catch (err) {
+                console.error("Failed to render book in search filter:", book.id, err);
+            }
+        }
+
+        // Process hydration in a staggered fashion to avoid 429 rate limits
+        let delayMs = 0;
+        for (const book of this.books) {
+            const bookElement = this.bookElements.get(book.id);
+            if (bookElement) {
+                setTimeout(() => {
+                    this.hydrateBookMoodTags(book, bookElement);
+                }, delayMs);
+                delayMs += 350; // Stagger by 350ms to respect backend rate limits
+            }
+        }
+
+        // If no elements were rendered, show error/empty
+        if (this.container.children.length === 0) {
+            this.container.innerHTML = '<p class="empty-state">No books available for this collection.</p>';
+        }
+    }
+
+    async hydrateBookMoodTags(book, bookElement, retryCount = 0) {
+        const title = book.volumeInfo?.title || "Untitled";
+        const authors = book.volumeInfo?.authors ? book.volumeInfo?.authors.join(", ") : "Unknown Author";
+
+        try {
+            const res = await this.renderer.fetchMoodTags(title, authors);
+
+            if (res && res.status === 429) {
+                // Rate limited! Retry after a delay if retryCount < 3
+                if (retryCount < 3) {
+                    const backoff = (retryCount + 1) * 1000;
+                    setTimeout(() => {
+                        this.hydrateBookMoodTags(book, bookElement, retryCount + 1);
+                    }, backoff);
+                    return;
+                }
+            }
+
+            if (res && res.ok) {
+                const data = await res.json();
+                const moods = data.data?.mood_tags || [];
+                if (moods && moods.length > 0) {
+                    book.moods = moods; // Save to book object
+
+                    // Update back face tags in DOM
+                    const backFace = bookElement.querySelector('.book__face--back > div');
+                    if (backFace) {
+                        let tagsEl = backFace.querySelector('.book-mood-tags');
+                        if (!tagsEl) {
+                            tagsEl = document.createElement('div');
+                            tagsEl.className = 'book-mood-tags';
+                            tagsEl.style.cssText = 'margin-bottom: 0.8rem; display: flex; flex-wrap: wrap; gap: 4px;';
+                            backFace.appendChild(tagsEl);
+                        }
+                        tagsEl.innerHTML = moods.map(m => `
+                            <span class="mood-tag-badge" data-mood="${m}" style="font-size: 0.6rem; background: rgba(0,0,0,0.1); padding: 2px 6px; border-radius: 10px; text-transform: capitalize; color: var(--text-main);">
+                                <i class="fa-solid ${this.renderer.getMoodIcon(m)}"></i> ${m}
+                            </span>
+                        `).join('');
+                    }
+
+                    // Add to unique moods set
+                    moods.forEach(mood => {
+                        // Standardize casing to capitalize first letter for cleaner chips display
+                        const cleanMood = mood.charAt(0).toUpperCase() + mood.slice(1).toLowerCase();
+                        this.uniqueMoods.add(cleanMood);
+                    });
+
+                    // Update filter chips bar
+                    this.renderFilterChips();
+
+                    // If this book matches the active filter
+                    this.updateBookVisibility(book.id);
+                }
+            }
+        } catch (e) {
+            console.warn("Failed to hydrate mood tags for", title, e);
+        }
+    }
+
+    renderFilterChips() {
+        if (!this.chipsContainer) return;
+
+        // If no moods loaded yet, don't show the bar
+        if (this.uniqueMoods.size === 0) {
+            this.filterBar.hidden = true;
+            return;
+        }
+
+        this.filterBar.hidden = false;
+
+        // Save current active element scroll or cursor position if needed
+        const prevScrollLeft = this.chipsContainer.scrollLeft;
+
+        this.chipsContainer.innerHTML = '';
+
+        // 1. Add "All" or "Clear Filter" chip
+        const allChip = document.createElement('div');
+        allChip.className = `filter-chip ${!this.activeFilter ? 'active' : ''}`;
+        allChip.innerHTML = `<i class="fa-solid fa-border-all"></i> All`;
+        allChip.addEventListener('click', () => this.setFilter(null));
+        this.chipsContainer.appendChild(allChip);
+
+        // 2. Add dynamic chips for unique moods
+        const sortedMoods = Array.from(this.uniqueMoods).sort();
+        sortedMoods.forEach(mood => {
+            const isChipActive = this.activeFilter && this.activeFilter.toLowerCase() === mood.toLowerCase();
+            const chip = document.createElement('div');
+            chip.className = `filter-chip ${isChipActive ? 'active' : ''}`;
+            chip.innerHTML = `<i class="fa-solid ${this.renderer.getMoodIcon(mood)}"></i> ${mood}`;
+            chip.addEventListener('click', () => this.setFilter(mood));
+            this.chipsContainer.appendChild(chip);
+        });
+
+        // Restore scroll position
+        this.chipsContainer.scrollLeft = prevScrollLeft;
+    }
+
+    setFilter(mood) {
+        if (mood) {
+            this.activeFilter = mood.toLowerCase();
+            sessionStorage.setItem('active_mood_filter', this.activeFilter);
+            
+            // Update URL query parameters without reloading the page
+            const url = new URL(window.location);
+            url.searchParams.set('mood', this.activeFilter);
+            window.history.pushState({}, '', url);
+        } else {
+            this.activeFilter = null;
+            sessionStorage.removeItem('active_mood_filter');
+            
+            // Remove mood query param
+            const url = new URL(window.location);
+            url.searchParams.delete('mood');
+            window.history.pushState({}, '', url);
+        }
+
+        // Render chips state update
+        this.renderFilterChips();
+
+        // Apply filtering logic to book elements
+        this.applyFilter();
+    }
+
+    updateBookVisibility(bookId) {
+        const element = this.bookElements.get(bookId);
+        if (!element) return;
+
+        const book = this.books.find(b => b.id === bookId);
+        if (!book) return;
+
+        let visible = true;
+        if (this.activeFilter) {
+            const bookMoods = (book.moods || []).map(m => m.toLowerCase());
+            visible = bookMoods.includes(this.activeFilter);
+        }
+
+        if (visible) {
+            element.style.display = 'block';
+            element.classList.remove('filtered-out');
+        } else {
+            element.style.display = 'none';
+            element.classList.add('filtered-out');
+        }
+    }
+
+    applyFilter() {
+        let visibleCount = 0;
+        
+        for (const [bookId, element] of this.bookElements.entries()) {
+            const book = this.books.find(b => b.id === bookId);
+            if (!book) continue;
+
+            let visible = true;
+            if (this.activeFilter) {
+                const bookMoods = (book.moods || []).map(m => m.toLowerCase());
+                visible = bookMoods.includes(this.activeFilter);
+            }
+
+            if (visible) {
+                element.style.display = 'block';
+                element.classList.remove('filtered-out');
+                visibleCount++;
+            } else {
+                element.style.display = 'none';
+                element.classList.add('filtered-out');
+            }
+        }
+
+        // Handle empty matching filter state
+        const existingEmptyState = this.container.querySelector('.empty-filter-state');
+        if (existingEmptyState) {
+            existingEmptyState.remove();
+        }
+
+        if (visibleCount === 0 && this.books.length > 0) {
+            const emptyState = document.createElement('div');
+            emptyState.className = 'empty-filter-state';
+            emptyState.id = 'empty-filter-state';
+            
+            const activeMoodName = this.activeFilter.charAt(0).toUpperCase() + this.activeFilter.slice(1);
+            emptyState.innerHTML = `
+                <i class="fa-solid ${this.renderer.getMoodIcon(this.activeFilter)}"></i>
+                <h3>No "${activeMoodName}" vibes on this shelf</h3>
+                <p>Try selecting a different mood chip to explore other avenues.</p>
+            `;
+            this.container.appendChild(emptyState);
         }
     }
 }

--- a/frontend/pages/index.html
+++ b/frontend/pages/index.html
@@ -92,6 +92,13 @@
         <h2 id="search-query-display">Search Results</h2>
         <span><i class="fa-solid fa-magnifying-glass"></i> Exploring your query</span>
       </div>
+      <!-- Mood-Tag Filter Bar -->
+      <div id="mood-filter-bar" class="mood-filter-bar" hidden>
+        <div class="filter-label">Filter by mood:</div>
+        <div class="filter-chips" id="filter-chips">
+          <!-- Dynamically populated chips -->
+        </div>
+      </div>
       <div class="curated-row" id="search-results-grid">
         <!-- Dynamically Appended Books -->
       </div>


### PR DESCRIPTION
- Fix invalid CSS syntax (move nested selectors out of :root, remove stray properties,
and correct typos that broke stylesheet parsing).

- Remove unsafe global cursor override and stray newline that caused
accessibility/UX regressions.

- Remove duplicate script and manifest imports, ensure config. js loads before
 `app.js` to restore globals (MOOD_API_BASE, API_BASE).
- Resolve module/load mismatch in `app.js`(avoid using import in non-module scripts or convert to
 `type="module"` ); guard DOM lookups (e.g.,
`.book-container-3d` ) to prevent runtime exceptions.

- Notes: These changes are focused and low-risk to restore runtime stability and
accessibility; unrelated feature/visual churn was intentionally not merged here.

- Manual checks: open `index.html`
locally, verify console has no import/CSS
errors, confirm theme toggle, search, and library rendering work; run service worker
and Dexie registrations once.


#### Closes #648 