### PR TITLE
 Migrate Goodreads mood cache to DB-backed storage

### DIFF
--- a/backend/migrations/versions/0003_add_mood_cache.py
+++ b/backend/migrations/versions/0003_add_mood_cache.py
@@ -1,0 +1,37 @@
+"""Add database-backed mood cache.
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-05-18 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '0003'
+down_revision = '0002'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'mood_cache',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('cache_key', sa.String(length=512), nullable=False),
+        sa.Column('book_title', sa.String(length=255), nullable=False),
+        sa.Column('book_author', sa.String(length=255), nullable=False),
+        sa.Column('analysis_json', sa.Text(), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.Column('updated_at', sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('cache_key', name='uq_mood_cache_key'),
+    )
+    op.create_index('ix_mood_cache_cache_key', 'mood_cache', ['cache_key'], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index('ix_mood_cache_cache_key', table_name='mood_cache')
+    op.drop_table('mood_cache')

--- a/backend/models.py
+++ b/backend/models.py
@@ -346,6 +346,20 @@ class BookNote(db.Model, SoftDeleteMixin):
         }
 
 
+class MoodCache(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    cache_key = db.Column(db.String(512), nullable=False, index=True)
+    book_title = db.Column(db.String(255), nullable=False)
+    book_author = db.Column(db.String(255), nullable=False, default="")
+    analysis_json = db.Column(db.Text, nullable=False)
+    created_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
+    updated_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
+
+    __table_args__ = (
+        db.UniqueConstraint('cache_key', name='uq_mood_cache_key'),
+    )
+
+
 class ReadingGoal(db.Model, SoftDeleteMixin):
     query_class = SoftDeleteQuery
     """Model for tracking user's annual reading goals."""

--- a/backend/mood_analysis/ai_service_enhanced.py
+++ b/backend/mood_analysis/ai_service_enhanced.py
@@ -5,19 +5,27 @@
 from .goodreads_scraper import GoodReadsReviewScraper
 from .mood_analyzer import BookMoodAnalyzer
 import json
-import os
 import logging
+from datetime import datetime, timedelta, timezone
 from typing import Dict, Optional
 
 # Import caching decorators
 try:
-    from cache_service import cache_mood_analysis, cache_mood_tags
+    from cache_service import cache_mood_tags, CacheConfig
 except ImportError:
     # Fallback if cache_service is not available
-    def cache_mood_analysis(func):
-        return func
     def cache_mood_tags(func):
         return func
+    class CacheConfig:
+        MOOD_ANALYSIS_TTL = 86400
+
+try:
+    from backend.models import db, MoodCache
+except ImportError:
+    from models import db, MoodCache
+
+
+logger = logging.getLogger(__name__)
 
 class AIBookService:
     """Enhanced AI service with GoodReads mood analysis integration."""
@@ -25,33 +33,60 @@ class AIBookService:
     def __init__(self):
         self.scraper = GoodReadsReviewScraper()
         self.mood_analyzer = BookMoodAnalyzer()
-        self.cache_file = os.path.join(os.path.dirname(__file__), 'mood_cache.json')
-        self.mood_cache = self._load_cache()
-    
-    def _load_cache(self) -> Dict:
-        """Load cached mood analyses to avoid re-scraping."""
-        if os.path.exists(self.cache_file):
-            try:
-                with open(self.cache_file, 'r') as f:
-                    return json.load(f)
-            except:
-                pass
-        return {}
-    
-    def _save_cache(self):
-        """Save mood analyses to cache."""
-        try:
-            with open(self.cache_file, 'w') as f:
-                json.dump(self.mood_cache, f, indent=2)
-        except Exception as e:
-            logger = logging.getLogger(__name__)
-            logger.error(f"Error saving cache: {e}")
     
     def _get_cache_key(self, title: str, author: str = "") -> str:
         """Generate cache key for book."""
         return f"{title.lower().strip()}|{author.lower().strip()}"
+
+    def _is_cache_fresh(self, cached_entry: MoodCache) -> bool:
+        """Check whether a cache entry is still valid."""
+        updated_at = cached_entry.updated_at
+        if updated_at is None:
+            return False
+
+        if updated_at.tzinfo is None:
+            updated_at = updated_at.replace(tzinfo=timezone.utc)
+
+        age = datetime.now(timezone.utc) - updated_at
+        return age <= timedelta(seconds=CacheConfig.MOOD_ANALYSIS_TTL)
+
+    def _load_cached_analysis(self, cache_key: str) -> Optional[Dict]:
+        """Load cached mood analysis from the database."""
+        cached_entry = MoodCache.query.filter_by(cache_key=cache_key).first()
+        if not cached_entry or not self._is_cache_fresh(cached_entry):
+            return None
+
+        try:
+            return json.loads(cached_entry.analysis_json)
+        except (TypeError, json.JSONDecodeError):
+            logger.warning("Invalid mood cache payload for key: %s", cache_key)
+            return None
+
+    def _store_cached_analysis(self, cache_key: str, title: str, author: str, mood_analysis: Dict) -> None:
+        """Persist mood analysis in the database cache."""
+        try:
+            cached_entry = MoodCache.query.filter_by(cache_key=cache_key).first()
+            payload = json.dumps(mood_analysis)
+
+            if cached_entry is None:
+                cached_entry = MoodCache(
+                    cache_key=cache_key,
+                    book_title=title.strip(),
+                    book_author=author.strip(),
+                    analysis_json=payload,
+                )
+                db.session.add(cached_entry)
+            else:
+                cached_entry.book_title = title.strip()
+                cached_entry.book_author = author.strip()
+                cached_entry.analysis_json = payload
+                cached_entry.updated_at = datetime.now(timezone.utc)
+
+            db.session.commit()
+        except Exception as e:
+            db.session.rollback()
+            logger.error("Error saving mood cache for %s: %s", cache_key, e)
     
-    @cache_mood_analysis
     def analyze_book_mood(self, title: str, author: str = "") -> Optional[Dict]:
         """
         Analyze book mood using GoodReads reviews.
@@ -66,17 +101,16 @@ class AIBookService:
         cache_key = self._get_cache_key(title, author)
         
         # Check cache first
-        if cache_key in self.mood_cache:
-            logger = logging.getLogger(__name__)
+        cached_analysis = self._load_cached_analysis(cache_key)
+        if cached_analysis is not None:
             logger.info(f"Using cached mood analysis for: {title}")
-            return self.mood_cache[cache_key]
+            return cached_analysis
         
         try:
             # Scrape reviews
             reviews = self.scraper.get_book_reviews(title, author, max_reviews=15)
             
             if not reviews:
-                logger = logging.getLogger(__name__)
                 logger.warning(f"No reviews found for: {title}")
                 return None
             
@@ -84,13 +118,12 @@ class AIBookService:
             mood_analysis = self.mood_analyzer.determine_primary_mood(reviews)
             
             # Cache the result
-            self.mood_cache[cache_key] = mood_analysis
-            self._save_cache()
+            if mood_analysis:
+                self._store_cached_analysis(cache_key, title, author, mood_analysis)
             
             return mood_analysis
             
         except Exception as e:
-            logger = logging.getLogger(__name__)
             logger.error(f"Error analyzing book mood: {e}")
             return None
 

--- a/tests/test_mood_cache_db.py
+++ b/tests/test_mood_cache_db.py
@@ -1,0 +1,128 @@
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from flask import Flask
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from backend.models import MoodCache, db
+from backend.mood_analysis.ai_service_enhanced import AIBookService, CacheConfig
+
+
+@pytest.fixture(scope='module')
+def flask_app():
+    app = Flask(__name__)
+    app.config.update(
+        TESTING=True,
+        SQLALCHEMY_DATABASE_URI='sqlite:///:memory:',
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+    )
+    db.init_app(app)
+
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture(autouse=True)
+def clear_mood_cache(flask_app):
+    with flask_app.app_context():
+        MoodCache.query.delete()
+        db.session.commit()
+        yield
+        MoodCache.query.delete()
+        db.session.commit()
+
+
+def test_analyze_book_mood_persists_to_db(flask_app):
+    with flask_app.app_context():
+        service = AIBookService()
+
+        with patch.object(service.scraper, 'get_book_reviews', return_value=['review one']), \
+             patch.object(
+                 service.mood_analyzer,
+                 'determine_primary_mood',
+                 return_value={
+                     'primary_moods': [{'mood': 'cozy'}],
+                     'bibliodrift_vibe': 'Warm and inviting',
+                 },
+             ):
+            result = service.analyze_book_mood('The Test Book', 'Test Author')
+
+        cache_key = 'the test book|test author'
+        cached_entry = MoodCache.query.filter_by(cache_key=cache_key).first()
+
+        assert result == {
+            'primary_moods': [{'mood': 'cozy'}],
+            'bibliodrift_vibe': 'Warm and inviting',
+        }
+        assert cached_entry is not None
+        assert json.loads(cached_entry.analysis_json) == result
+
+
+def test_analyze_book_mood_uses_cached_row(flask_app):
+    with flask_app.app_context():
+        service = AIBookService()
+
+        with patch.object(service.scraper, 'get_book_reviews', return_value=['review one']), \
+             patch.object(
+                 service.mood_analyzer,
+                 'determine_primary_mood',
+                 return_value={
+                     'primary_moods': [{'mood': 'mysterious'}],
+                     'bibliodrift_vibe': 'Quiet and mysterious',
+                 },
+             ):
+            first_result = service.analyze_book_mood('Cached Book', 'Cached Author')
+
+        with patch.object(service.scraper, 'get_book_reviews', side_effect=AssertionError('scraper should not run')), \
+             patch.object(service.mood_analyzer, 'determine_primary_mood', side_effect=AssertionError('analyzer should not run')):
+            second_result = service.analyze_book_mood('Cached Book', 'Cached Author')
+
+        assert second_result == first_result
+        assert MoodCache.query.filter_by(cache_key='cached book|cached author').count() == 1
+
+
+def test_analyze_book_mood_refreshes_stale_row(flask_app):
+    with flask_app.app_context():
+        service = AIBookService()
+
+        with patch.object(service.scraper, 'get_book_reviews', return_value=['old review']), \
+             patch.object(
+                 service.mood_analyzer,
+                 'determine_primary_mood',
+                 return_value={
+                     'primary_moods': [{'mood': 'dark'}],
+                     'bibliodrift_vibe': 'Dark and brooding',
+                 },
+             ):
+            service.analyze_book_mood('Stale Book', 'Stale Author')
+
+        cached_entry = MoodCache.query.filter_by(cache_key='stale book|stale author').first()
+        cached_entry.updated_at = datetime.now(timezone.utc) - timedelta(seconds=CacheConfig.MOOD_ANALYSIS_TTL + 10)
+        db.session.commit()
+
+        with patch.object(service.scraper, 'get_book_reviews', return_value=['fresh review']), \
+             patch.object(
+                 service.mood_analyzer,
+                 'determine_primary_mood',
+                 return_value={
+                     'primary_moods': [{'mood': 'uplifting'}],
+                     'bibliodrift_vibe': 'Bright and uplifting',
+                 },
+             ):
+            refreshed_result = service.analyze_book_mood('Stale Book', 'Stale Author')
+
+        refreshed_entry = MoodCache.query.filter_by(cache_key='stale book|stale author').first()
+
+        assert refreshed_result == {
+            'primary_moods': [{'mood': 'uplifting'}],
+            'bibliodrift_vibe': 'Bright and uplifting',
+        }
+        assert json.loads(refreshed_entry.analysis_json) == refreshed_result


### PR DESCRIPTION
## Description
Moves Goodreads mood analysis caching from the local JSON file to a database-backed `MoodCache` model. This keeps cache data persistent across instances, preserves the existing API response shape, and adds a migration for fresh and existing databases.

## Related Issue
Fixes #649 
## Type of Change
- [ ] Bug Fix
- [ ] Feature
- [x] Enhancement
- [ ] Documentation

## Testing
Validated with:
- `python -m pytest tests/test_mood_cache_db.py -q`
- `python -m pytest tests/test_mood_improvements.py -q`

## Screenshots
N/A

## Checklist
- [x] Code follows guidelines
- [x] Tested properly
- [x] Docs updated
- [x] PR title includes the relevant event tag or a general contribution label