### PR TITLE
Complete offline library sync queue(#650)

### DIFF
--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -228,17 +228,16 @@ const CollectionAPI = {
     }
 };
 window.CollectionAPI = CollectionAPI;
-import { saveBookOffline, removeOfflineBook, db } from './db.js';
 
 // Example click handler for your custom "Save for Offline" icon
 async function handleDownloadToggle(bookCard, bookData) {
-    const isAlreadyDownloaded = await db.downloadedBooks.get(bookData.id);
+    const isAlreadyDownloaded = await window.db.downloadedBooks.get(bookData.id);
     
     if (isAlreadyDownloaded) {
-        const success = await removeOfflineBook(bookData.id);
+        const success = await window.removeOfflineBook(bookData.id);
         if (success) bookCard.classList.remove('is-downloaded');
     } else {
-        const success = await saveBookOffline(bookData);
+        const success = await window.saveBookOffline(bookData);
         if (success) bookCard.classList.add('is-downloaded');
     }
 }
@@ -1552,6 +1551,10 @@ class LibraryManager {
 
         // 4. Sync with backend if available (Full Refresh)
         await this.syncWithBackend();
+        if (navigator.onLine) {
+            await this.flushPendingLibraryMutations();
+        }
+        await this.updateSyncStatus();
     }
 
     getUser() {
@@ -1569,6 +1572,194 @@ class LibraryManager {
             headers['X-CSRF-TOKEN'] = csrfToken;
         }
         return new Headers(headers);
+    }
+
+    async _getPendingSyncCount() {
+        const user = this.getUser();
+        if (!user || !window.db?.syncQueue) return 0;
+        return await window.db.syncQueue.where('userId').equals(user.id).count();
+    }
+
+    async updateSyncStatus() {
+        const statusEl = document.getElementById('library-sync-status');
+        if (!statusEl) return;
+
+        const pendingCount = await this._getPendingSyncCount();
+        statusEl.hidden = false;
+        statusEl.textContent = pendingCount > 0
+            ? `${pendingCount} pending sync${pendingCount === 1 ? '' : 's'}`
+            : 'Synced';
+        statusEl.dataset.state = pendingCount > 0 ? 'pending' : 'synced';
+    }
+
+    async _queueMutation(action, book, extra = {}) {
+        if (typeof window.enqueueLibraryMutation !== 'function') return;
+
+        const user = this.getUser();
+        if (!user || !window.db?.syncQueue) return;
+
+        const snapshot = JSON.parse(JSON.stringify(book));
+
+        const existingMutations = (await window.db.syncQueue.where('userId').equals(user.id).toArray())
+            .filter((mutation) => mutation.bookId === snapshot.id);
+
+        if (action === 'remove') {
+            await Promise.all(existingMutations.map((mutation) => window.db.syncQueue.delete(mutation.id)));
+            await this.updateSyncStatus();
+            return;
+        }
+
+        const shelf = extra.shelf || this.findBookShelf(snapshot.id) || null;
+        const mergedMutation = {
+            userId: user.id,
+            action,
+            bookId: snapshot.id,
+            db_id: snapshot.db_id || null,
+            shelf,
+            payload: extra,
+            book: snapshot
+        };
+
+        const pendingAdd = existingMutations.find((mutation) => mutation.action === 'add');
+        if (pendingAdd && (action === 'move' || action === 'update')) {
+            await window.db.syncQueue.put({
+                ...pendingAdd,
+                db_id: mergedMutation.db_id || pendingAdd.db_id || null,
+                shelf: action === 'move' ? extra.toShelf || pendingAdd.shelf : pendingAdd.shelf,
+                payload: {
+                    ...(pendingAdd.payload || {}),
+                    ...extra
+                },
+                book: snapshot,
+                createdAt: pendingAdd.createdAt || new Date().toISOString()
+            });
+            await this.updateSyncStatus();
+            return;
+        }
+
+        if (action === 'add') {
+            await Promise.all(existingMutations.map((mutation) => window.db.syncQueue.delete(mutation.id)));
+        }
+
+        await window.enqueueLibraryMutation(mergedMutation);
+        await this.updateSyncStatus();
+    }
+
+    async _applyQueuedMutation(mutation) {
+        const user = this.getUser();
+        if (!user) return;
+
+        const localBookResult = this.findBookInShelf(mutation.bookId);
+        const localBook = localBookResult?.book || mutation.book;
+        const dbId = localBook?.db_id || mutation.db_id;
+
+        if (mutation.action === 'add') {
+            if (!localBook) return;
+
+            const payload = {
+                user_id: user.id,
+                google_books_id: localBook.id,
+                title: localBook.volumeInfo?.title || localBook.title || '',
+                authors: localBook.volumeInfo?.authors ? localBook.volumeInfo.authors.join(', ') : '',
+                thumbnail: localBook.volumeInfo?.imageLinks?.thumbnail || '',
+                shelf_type: mutation.shelf || mutation.payload?.shelf || 'want'
+            };
+
+            const res = await fetch(`${this.apiBase}/library`, {
+                method: 'POST',
+                headers: this.getAuthHeaders(),
+                credentials: 'include',
+                body: JSON.stringify(payload)
+            });
+
+            if (!res.ok) {
+                const data = await res.json().catch(() => ({}));
+                throw new Error(data.error || `HTTP ${res.status}`);
+            }
+
+            const data = await res.json();
+            if (localBook) {
+                localBook.db_id = data.item.id;
+                localBook.version = data.item.version;
+                this.saveLocally();
+            }
+            return;
+        }
+
+        if (mutation.action === 'remove') {
+            if (!dbId) return;
+
+            const res = await fetch(`${this.apiBase}/library/${dbId}`, {
+                method: 'DELETE',
+                headers: this.getAuthHeaders(),
+                credentials: 'include'
+            });
+
+            if (!res.ok) {
+                const data = await res.json().catch(() => ({}));
+                throw new Error(data.error || `HTTP ${res.status}`);
+            }
+            return;
+        }
+
+        if (mutation.action === 'move' || mutation.action === 'update') {
+            if (!dbId || !localBook) return;
+
+            const body = mutation.action === 'move'
+                ? {
+                    shelf_type: mutation.payload?.toShelf,
+                    progress: localBook.progress,
+                    version: localBook.version
+                }
+                : {
+                    ...mutation.payload?.updates,
+                    version: localBook.version
+                };
+
+            const res = await fetch(`${this.apiBase}/library/${dbId}`, {
+                method: 'PUT',
+                headers: this.getAuthHeaders(),
+                credentials: 'include',
+                body: JSON.stringify(body)
+            });
+
+            if (!res.ok) {
+                const data = await res.json().catch(() => ({}));
+                throw new Error(data.error || `HTTP ${res.status}`);
+            }
+
+            const data = await res.json();
+            localBook.version = data.item.version;
+            this.saveLocally();
+        }
+    }
+
+    async flushPendingLibraryMutations() {
+        const user = this.getUser();
+        if (!user || !window.db?.syncQueue) {
+            await this.updateSyncStatus();
+            return 0;
+        }
+
+        const pendingMutations = await window.db.syncQueue.where('userId').equals(user.id).sortBy('createdAt');
+        if (pendingMutations.length === 0) {
+            await this.updateSyncStatus();
+            return 0;
+        }
+
+        let processed = 0;
+        for (const mutation of pendingMutations) {
+            await this._applyQueuedMutation(mutation);
+            await window.db.syncQueue.delete(mutation.id);
+            processed += 1;
+        }
+
+        if (processed > 0) {
+            await this.syncWithBackend();
+        }
+
+        await this.updateSyncStatus();
+        return processed;
     }
 
     async syncWithBackend() {
@@ -1663,6 +1854,7 @@ class LibraryManager {
                         this.renderShelf('finished', 'shelf-finished');
                     }
                 }
+                await this.updateSyncStatus();
             }
         } catch (e) {
             console.error("Sync failed", e);
@@ -1720,6 +1912,7 @@ class LibraryManager {
 
                 // After upload, pull fresh state from backend to get the new DB IDs and versions
                 await this.syncWithBackend();
+                await this.updateSyncStatus();
             } else {
                 const data = await res.json();
                 console.error("Backend refused sync", data);
@@ -1889,10 +2082,12 @@ class LibraryManager {
                     enrichedBook.db_id = data.item.id;
                     enrichedBook.version = data.item.version;
                     this.saveLocally();
+                    await this.updateSyncStatus();
                 }
             } catch (e) {
                 console.error("Failed to save to backend", e);
-                showToast("Saved locally (Sync failed)", "info");
+                await this._queueMutation('add', enrichedBook, { shelf });
+                showToast("Saved locally; sync queued", "info");
             }
         }
     }
@@ -1938,6 +2133,7 @@ class LibraryManager {
                     const data = await res.json();
                     book.version = data.item.version;
                     this.saveLocally();
+                    await this.updateSyncStatus();
                 } else if (res.status === 409) {
                     const data = await res.json();
                     showToast("Conflict detected! Syncing with server...", "error");
@@ -1949,7 +2145,8 @@ class LibraryManager {
                 }
             } catch (e) {
                 console.error("Failed to update backend", e);
-                showToast("Saved locally (Sync failed)", "info");
+                await this._queueMutation('update', book, { updates });
+                showToast("Saved locally; sync queued", "info");
             }
         }
     }
@@ -2013,9 +2210,11 @@ class LibraryManager {
                         headers: this.getAuthHeaders(),
                         credentials: 'include'
                     });
+                    await this.updateSyncStatus();
                 } catch (e) {
                     console.error("Failed to delete from backend", e);
-                    showToast("Removed locally (Backend sync failed)", "info");
+                    await this._queueMutation('remove', book, { shelf });
+                    showToast("Removed locally; sync queued", "info");
                 }
             } else if (user) {
                 // Fallback: If we don't have db_id locally (maybe added before login logic), 
@@ -2067,6 +2266,7 @@ class LibraryManager {
                     const data = await res.json();
                     book.version = data.item.version;
                     this.saveLocally();
+                    await this.updateSyncStatus();
                 } else if (res.status === 409) {
                     showToast("Conflict detected! Syncing with server...", "error");
                     await this.syncWithBackend();
@@ -2077,10 +2277,12 @@ class LibraryManager {
                 }
             } catch (e) {
                 console.error("Failed to update backend during move", e);
-                showToast("Moved locally (Sync failed)", "info");
+                await this._queueMutation('move', book, { fromShelf, toShelf });
+                showToast("Moved locally; sync queued", "info");
             }
         }
 
+        await this.updateSyncStatus();
         return true;
     }
 

--- a/frontend/js/db.js
+++ b/frontend/js/db.js
@@ -1,30 +1,80 @@
-// Initialize Dexie Database globally
-window.db = new Dexie("BiblioDriftDB");
+(function () {
+    const DB_NAME = 'BiblioDriftDB';
+    const BOOKS_SCHEMA = 'id, title, author, content, mood, coverUrl';
+    const DOWNLOADED_BOOKS_SCHEMA = 'id, title, author, content, mood, coverUrl, downloadedAt';
+    const SYNC_QUEUE_SCHEMA = '++id, userId, action, bookId, db_id, shelf, createdAt';
 
-// Define schema
-window.db.version(1).stores({
-    books: 'id, title, author, content, mood, coverUrl'
-});
-
-console.log("IndexedDB configuration loaded onto window.db!");
-// A safe initialization wrapper
-function initDatabase() {
-    if (typeof Dexie === 'undefined') {
-        console.error("Dexie CDN is still loading... Retrying in 50ms.");
-        setTimeout(initDatabase, 50);
-        return;
+    function dispatchSyncQueueEvent(userId) {
+        window.dispatchEvent(new CustomEvent('bibliodrift:library-sync-queued', {
+            detail: { userId }
+        }));
     }
 
-    // Initialize Dexie Database globally on the window object
-    window.db = new Dexie("BiblioDriftDB");
+    async function getPendingLibrarySyncCount(userId) {
+        if (!window.db?.syncQueue) return 0;
+        if (userId == null) {
+            return await window.db.syncQueue.count();
+        }
+        return await window.db.syncQueue.where('userId').equals(userId).count();
+    }
 
-    // Define schema: Store books by 'id'
-    window.db.version(1).stores({
-        books: 'id, title, author, content, mood, coverUrl'
-    });
+    function initDatabase() {
+        if (typeof Dexie === 'undefined') {
+            console.error('Dexie CDN is still loading... Retrying in 50ms.');
+            setTimeout(initDatabase, 50);
+            return;
+        }
 
-    console.log("IndexedDB configuration loaded onto window.db successfully!");
-}
+        if (window.db?.name === DB_NAME) {
+            return;
+        }
 
-// Execute the safe initializer
-initDatabase();
+        window.db = new Dexie(DB_NAME);
+        window.db.version(1).stores({
+            books: BOOKS_SCHEMA,
+            downloadedBooks: DOWNLOADED_BOOKS_SCHEMA
+        });
+        window.db.version(2).stores({
+            books: BOOKS_SCHEMA,
+            downloadedBooks: DOWNLOADED_BOOKS_SCHEMA,
+            syncQueue: SYNC_QUEUE_SCHEMA
+        });
+
+        window.db.open().catch((error) => {
+            console.error('Failed to open BiblioDrift IndexedDB', error);
+        });
+
+        window.saveBookOffline = async function (book) {
+            if (!window.db?.downloadedBooks || !book?.id) return false;
+            await window.db.downloadedBooks.put({
+                ...book,
+                downloadedAt: new Date().toISOString()
+            });
+            return true;
+        };
+
+        window.removeOfflineBook = async function (bookId) {
+            if (!window.db?.downloadedBooks || !bookId) return false;
+            await window.db.downloadedBooks.delete(bookId);
+            return true;
+        };
+
+        window.enqueueLibraryMutation = async function (mutation) {
+            if (!window.db?.syncQueue) return null;
+
+            const entry = {
+                ...mutation,
+                createdAt: mutation.createdAt || new Date().toISOString()
+            };
+            const id = await window.db.syncQueue.add(entry);
+            dispatchSyncQueueEvent(entry.userId ?? null);
+            return id;
+        };
+
+        window.getPendingLibrarySyncCount = getPendingLibrarySyncCount;
+
+        console.log('IndexedDB configuration loaded onto window.db successfully!');
+    }
+
+    initDatabase();
+})();

--- a/frontend/js/pwa.js
+++ b/frontend/js/pwa.js
@@ -29,6 +29,7 @@
     const SW_SCOPE = '/frontend/';
 
     let _swRegistration = null;
+    let _syncRequestInFlight = false;
 
     navigator.serviceWorker.register(SW_URL, { scope: SW_SCOPE })
         .then((registration) => {
@@ -55,6 +56,27 @@
             console.warn('[PWA] Service worker registration failed:', err);
         });
 
+    async function _requestLibrarySync() {
+        if (_syncRequestInFlight) return;
+        _syncRequestInFlight = true;
+
+        try {
+            if (_swRegistration && 'sync' in _swRegistration) {
+                await _swRegistration.sync.register('bibliodrift-library-sync');
+            }
+
+            if (navigator.onLine && window.libManager && typeof window.libManager.flushPendingLibraryMutations === 'function') {
+                await window.libManager.flushPendingLibraryMutations();
+            }
+        } catch (err) {
+            console.warn('[PWA] Failed to request library sync:', err);
+        } finally {
+            _syncRequestInFlight = false;
+        }
+    }
+
+    window.requestLibrarySync = _requestLibrarySync;
+
     // Reload the page once the new SW has taken control
     navigator.serviceWorker.addEventListener('controllerchange', () => {
         window.location.reload();
@@ -63,17 +85,16 @@
     // Listen for messages from the SW (e.g. background sync trigger)
     navigator.serviceWorker.addEventListener('message', (event) => {
         if (event.data?.type === 'SYNC_LIBRARY') {
-            // Delegate to LibraryManager if it's available on this page
-            if (window.libManager && typeof window.libManager.syncLocalToBackend === 'function') {
-                const user = window.libManager.getUser?.();
-                if (user) {
-                    window.libManager.syncLocalToBackend(user).catch((err) => {
-                        console.warn('[PWA] Background library sync failed:', err);
-                    });
-                }
+            if (window.libManager && typeof window.libManager.flushPendingLibraryMutations === 'function') {
+                window.libManager.flushPendingLibraryMutations().catch((err) => {
+                    console.warn('[PWA] Background library sync failed:', err);
+                });
             }
         }
     });
+
+    window.addEventListener('bibliodrift:library-sync-queued', _requestLibrarySync);
+    window.addEventListener('online', _requestLibrarySync);
 
     // ── Install Prompt (A2HS) ──────────────────────────────────────────────────
 

--- a/frontend/pages/library.html
+++ b/frontend/pages/library.html
@@ -83,6 +83,9 @@
             <button id="export-library" class="btn-icon library-export-btn" title="Export Library">
                 <i class="fa-solid fa-download"></i> Export Library
             </button>
+            <div id="library-sync-status" hidden aria-live="polite" style="margin: 0.75rem auto 0; display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.35rem 0.8rem; border-radius: 999px; font-size: 0.85rem; background: rgba(44, 36, 32, 0.08); color: var(--text-secondary);">
+                Synced
+            </div>
             <div class="view-toggles" style="margin-top: 1.5rem; display: flex; justify-content: center; gap: 1rem;">
                 <button id="view-shelves-btn" class="btn-primary active-view" style="border-radius: 20px; padding: 0.5rem 1.5rem;">
                     <i class="fa-solid fa-server"></i> Shelves


### PR DESCRIPTION
## Summary
Complete the offline library sync queue so shelf changes made while offline are safely persisted, replayed later, and surfaced with a small pending-sync indicator.

## What Changed
- Added a Dexie-backed `syncQueue` store for offline library mutations.
- Reused the existing library sync flow to flush queued add, move, update, and remove actions.
- Added queue compaction so stale offline sequences do not replay duplicates or ghost records.
- Wired PWA sync triggers and online fallback handling.
- Added a compact pending-sync badge on the library page.

## Validation
- `node --check frontend/js/db.js frontend/js/app.js frontend/js/pwa.js frontend/sw.js`
- Manual offline/online browser verification still recommended for the Background Sync flow.

## Notes
- Scope kept intentionally small and limited to the existing library/PWA architecture.
- No unrelated refactors or broader offline-search changes were introduced.


### Closes #650 