### PR TITLE
Feat: Integrate backend reading stats and goals into profile

### DIFF
--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -2502,6 +2502,128 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (statWantDashEl) statWantDashEl.textContent = wantCount;
         if (statVibeEl) statVibeEl.textContent = topVibe;
 
+        // Initialize Extended Stats (Goals, Streak, Leaderboard)
+        const currentYear = new Date().getFullYear();
+        if (document.getElementById('current-year-display')) {
+            document.getElementById('current-year-display').textContent = currentYear;
+        }
+
+        const loadExtendedStats = async () => {
+            const token = SafeStorage.get('bibliodrift_token');
+            if (!token) return;
+
+            try {
+                // Fetch Stats & Goals
+                const statsResponse = await fetch(`${MOOD_API_BASE}/stats?user_id=${user.id}&year=${currentYear}`, {
+                    headers: { 'Authorization': `Bearer ${token}` }
+                });
+                
+                if (statsResponse.ok) {
+                    const stats = await statsResponse.json();
+                    
+                    // Update Streak
+                    if (stats.current_streak > 0) {
+                        const streakBadge = document.getElementById('streak-badge');
+                        const streakCount = document.getElementById('streak-count');
+                        if (streakBadge && streakCount) {
+                            streakBadge.style.display = 'inline-block';
+                            streakCount.textContent = stats.current_streak;
+                        }
+                    }
+
+                    // Update Goal Progress
+                    if (stats.goal) {
+                        const progressText = document.getElementById('goal-progress-text');
+                        const barGoal = document.getElementById('bar-goal');
+                        const target = stats.goal.target_books || 0;
+                        const completed = stats.books_this_year || 0;
+
+                        if (progressText) progressText.textContent = `${completed} / ${target} books`;
+                        if (barGoal && target > 0) {
+                            barGoal.style.width = `${Math.min(100, (completed / target) * 100)}%`;
+                        }
+                    } else {
+                        const progressText = document.getElementById('goal-progress-text');
+                        if (progressText) progressText.textContent = 'No goal set for this year';
+                    }
+                }
+
+                // Fetch Leaderboard
+                const lbResponse = await fetch(`${MOOD_API_BASE}/stats/leaderboard?year=${currentYear}&limit=5`, {
+                    headers: { 'Authorization': `Bearer ${token}` }
+                });
+
+                if (lbResponse.ok) {
+                    const leaderboard = await lbResponse.json();
+                    const lbSection = document.getElementById('leaderboard-section');
+                    const lbList = document.getElementById('leaderboard-list');
+                    
+                    if (leaderboard && leaderboard.length > 0 && lbSection && lbList) {
+                        lbSection.style.display = 'block';
+                        lbList.innerHTML = leaderboard.map((entry, index) => `
+                            <div class="leaderboard-entry" style="display: flex; align-items: center; justify-content: space-between; padding: 10px; border-bottom: 1px solid var(--border-color); ${entry.user_id === user.id ? 'background: rgba(139, 115, 85, 0.1); border-radius: 8px;' : ''}">
+                                <div style="display: flex; align-items: center; gap: 15px;">
+                                    <span style="font-weight: bold; min-width: 25px;">#${index + 1}</span>
+                                    <span>${entry.username} ${entry.user_id === user.id ? '(You)' : ''}</span>
+                                </div>
+                                <div style="text-align: right;">
+                                    <div style="font-weight: 600;">${entry.total_books} books</div>
+                                    <div style="font-size: 0.75rem; color: var(--text-muted);">${entry.total_pages.toLocaleString()} pages</div>
+                                </div>
+                            </div>
+                        `).join('');
+                    }
+                }
+            } catch (error) {
+                console.error('Error loading extended stats:', error);
+            }
+        };
+
+        // Goal Editing Logic
+        const editGoalBtn = document.getElementById('edit-goal-btn');
+        const saveGoalBtn = document.getElementById('save-goal-btn');
+        const goalInput = document.getElementById('goal-input');
+        const goalEditGroup = document.getElementById('goal-edit-group');
+
+        if (editGoalBtn) {
+            editGoalBtn.addEventListener('click', () => {
+                goalEditGroup.style.display = goalEditGroup.style.display === 'none' ? 'flex' : 'none';
+                if (goalEditGroup.style.display === 'flex') goalInput.focus();
+            });
+        }
+
+        if (saveGoalBtn) {
+            saveGoalBtn.addEventListener('click', async () => {
+                const target = parseInt(goalInput.value);
+                if (isNaN(target) || target < 1) return;
+
+                const token = SafeStorage.get('bibliodrift_token');
+                try {
+                    const response = await fetch(`${MOOD_API_BASE}/stats/goal`, {
+                        method: 'POST',
+                        headers: {
+                            'Authorization': `Bearer ${token}`,
+                            'Content-Type': 'application/json'
+                        },
+                        body: JSON.stringify({
+                            user_id: user.id,
+                            year: currentYear,
+                            target_books: target
+                        })
+                    });
+
+                    if (response.ok) {
+                        goalEditGroup.style.display = 'none';
+                        loadExtendedStats(); // Refresh
+                    }
+                } catch (error) {
+                    console.error('Failed to save goal:', error);
+                }
+            });
+        }
+
+        loadExtendedStats();
+
         // Progress Bar Calculation
         const barFinished = document.getElementById('bar-finished');
         const barCurrent = document.getElementById('bar-current');

--- a/frontend/pages/profile.html
+++ b/frontend/pages/profile.html
@@ -94,6 +94,31 @@
                     </div>
                 </div>
 
+                <!-- Yearly Reading Goal -->
+                <div class="profile-stat-box reading-goal-box" style="margin-top: 1rem;">
+                    <h3 class="progress-title"><i class="fa-solid fa-bullseye"></i> <span id="current-year-display">2024</span> Reading Goal</h3>
+                    <div id="goal-container">
+                        <div class="goal-stats" style="margin: 1rem 0;">
+                            <span id="goal-progress-text">0 / 0 books</span>
+                            <div class="progress-bar-container" style="height: 10px; margin-top: 5px;">
+                                <div id="bar-goal" class="progress-segment finished" style="width: 0%; background: var(--accent-color);"></div>
+                            </div>
+                        </div>
+                        <div class="goal-input-group" style="display: none; gap: 10px; margin-bottom: 1rem;" id="goal-edit-group">
+                            <input type="number" id="goal-input" min="1" max="1000" placeholder="Books" style="width: 80px; padding: 5px; border-radius: 4px; border: 1px solid var(--border-color); background: var(--card-bg); color: var(--text-color);">
+                            <button id="save-goal-btn" class="action-btn-primary" style="padding: 5px 15px; font-size: 0.8rem;">Save</button>
+                        </div>
+                        <div class="profile-actions">
+                            <span id="streak-badge" title="Reading Streak" style="display: none; background: #ff980022; color: #ff9800; padding: 4px 10px; border-radius: 20px; font-size: 0.8rem; margin-right: 10px;">
+                                <i class="fa-solid fa-fire"></i> <span id="streak-count">0</span> day streak
+                            </span>
+                            <button id="edit-goal-btn" class="action-btn-secondary" style="font-size: 0.8rem; padding: 4px 10px;">
+                                <i class="fa-solid fa-pen"></i> Edit Goal
+                            </button>
+                        </div>
+                    </div>
+                </div>
+
                 <div class="progress-breakdown profile-stat-box">
                     <h3 class="progress-title"><i class="fa-solid fa-chart-bar"></i> Reading Progress</h3>
                     <div class="progress-bar-container">
@@ -152,6 +177,13 @@
                     <div class="empty-state">
                         <p>No recent activity recorded.</p>
                     </div>
+                </div>
+            </div>
+
+            <div class="leaderboard-section profile-stat-box" id="leaderboard-section" style="display: none; margin-top: 2rem;">
+                <h2><i class="fa-solid fa-ranking-star"></i> Reading Leaderboard</h2>
+                <div id="leaderboard-list" style="margin-top: 1rem;">
+                    <!-- Injected by JS -->
                 </div>
             </div>
         </section>


### PR DESCRIPTION
## Description
This PR integrates the user profile page with the backend Reading Stats, Goals, and Leaderboard APIs. Previously, the profile page only displayed statistics derived from the local browser storage. This update enables a cross-device, data-driven experience for authenticated users while maintaining a graceful offline fallback.

## Key Changes
- **Reading Goals UI**: Added a new section to `profile.html` to display progress towards an annual reading target.
- **Goal Management**: Implemented an "Edit Goal" feature that allows users to set or update their yearly target via `POST /api/v1/stats/goal`.
- **Streak & Stats Integration**: Fetches real-time reading streaks and year-to-date totals (books/pages) from `GET /api/v1/stats`.
- **Community Leaderboard**: Added a "Top Readers" widget that surfaces the community leaderboard from `GET /api/v1/stats/leaderboard`.
- **Resilience**: Integrated `try-catch` handlers for all API calls to ensure the page functional using local shelf data if the backend is unreachable.

## Screenshots / UI
- [x] Streak badge (visible when > 0)
- [x] Reading goal progress bar
- [x] Dynamic leaderboard list

## Acceptance Criteria
- [x] Logged-in users see server-side stats.
- [x] Annual goal can be updated and persists on refresh.
- [x] Leaderboard displays top users and highlights the current user.
- [x] Offline mode correctly falls back to local `libManager` stats without errors.

## Related Issue
Fixes #651