### PR TITLE
fix(frontend): use same-origin MOOD_API_BASE on Netlify; stop localhost calls from public hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ where stories are explored through <b>mood, atmosphere, and feeling</b> instead 
 </p>
 
 
-[🚀 Live Demo](https://bibliodrift-dm.netlify.app/) •
+[🚀 Live Demo](https://bibliodrift-dm.netlify.app/) (static frontend; AI/auth need a deployed backend — see [docs/contributing.md](docs/contributing.md)) •
 [📚 Documentation](docs/) •
 [🤝 Contributing](docs/contributing.md)
 

--- a/build_netlify.py
+++ b/build_netlify.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import shutil
 from pathlib import Path
 
@@ -53,11 +54,25 @@ def build_html() -> None:
         target_file.write_text(rewrite_html(content), encoding="utf-8")
 
 
+def inject_api_base_override() -> None:
+    """Optional Netlify build env MOOD_API_BASE → runtime override in dist config.js."""
+    api_base = os.getenv("MOOD_API_BASE", "").strip()
+    if not api_base:
+        return
+    config_path = DIST / "js" / "config.js"
+    if not config_path.exists():
+        return
+    snippet = f'window.__MOOD_API_BASE_OVERRIDE__ = {api_base!r};\n'
+    content = config_path.read_text(encoding="utf-8")
+    config_path.write_text(snippet + content, encoding="utf-8")
+
+
 def main() -> None:
     reset_dist()
     for folder in ("css", "js", "assets", "script"):
         copy_tree(folder)
     build_html()
+    inject_api_base_override()
 
 
 if __name__ == "__main__":

--- a/frontend/js/chat.js
+++ b/frontend/js/chat.js
@@ -11,13 +11,6 @@ class ChatInterface {
         this.conversationHistory = [];
         this.isProcessing = false;
 
-        // Ensure backend connection is initialized with proper fallback
-        if (typeof window !== 'undefined') {
-            if (!window.MOOD_API_BASE || window.MOOD_API_BASE.includes(':5001')) {
-                window.MOOD_API_BASE = 'http://127.0.0.1:5000/api/v1';
-            }
-        }
-
         this.init();
     }
 
@@ -211,7 +204,7 @@ Tell me: what is stirring in you today?`,
     async getBooksellerResponse(userMessage) {
         // First, try to use the dedicated chat endpoint
         try {
-            const moodApiBase = window.MOOD_API_BASE || 'http://127.0.0.1:5000/api/v1';
+            const moodApiBase = window.MOOD_API_BASE || '/api/v1';
             const chatResponse = await fetch(`${moodApiBase}/chat`, {
                 method: 'POST',
                 headers: {
@@ -243,7 +236,7 @@ Tell me: what is stirring in you today?`,
 
         // Fallback to mood search
         try {
-            const moodApiBase = window.MOOD_API_BASE || 'http://127.0.0.1:5000/api/v1';
+            const moodApiBase = window.MOOD_API_BASE || '/api/v1';
             const moodResponse = await fetch(`${moodApiBase}/mood-search`, {
                 method: 'POST',
                 headers: {

--- a/frontend/js/config.js
+++ b/frontend/js/config.js
@@ -1,5 +1,26 @@
-// API Base URL - point to the local backend server
-const MOOD_API_BASE = 'http://127.0.0.1:5000/api/v1';
+const LOCAL_MOOD_API_BASE = 'http://127.0.0.1:5000/api/v1';
+
+/**
+ * Resolve API base for dev vs static hosting (Netlify, etc.).
+ * Public HTTPS pages must not call loopback (127.0.0.1); use same-origin /api/v1
+ * when a reverse proxy or Netlify redirect points /api to a deployed backend.
+ * Optional build-time override: window.__MOOD_API_BASE_OVERRIDE__ (see build_netlify.py).
+ */
+function resolveMoodApiBase() {
+    if (typeof window !== 'undefined' && window.__MOOD_API_BASE_OVERRIDE__) {
+        return String(window.__MOOD_API_BASE_OVERRIDE__).replace(/\/$/, '');
+    }
+    if (typeof window === 'undefined') {
+        return LOCAL_MOOD_API_BASE;
+    }
+    const host = window.location.hostname;
+    if (host === 'localhost' || host === '127.0.0.1') {
+        return LOCAL_MOOD_API_BASE;
+    }
+    return `${window.location.origin}/api/v1`;
+}
+
+const MOOD_API_BASE = resolveMoodApiBase();
 
 const CONFIG = {
     // Google Books API - loaded from backend config endpoint
@@ -24,7 +45,7 @@ const CONFIG = {
 
 if (typeof window !== 'undefined') {
     window.CONFIG = CONFIG;
-    window.MOOD_API_BASE = 'http://127.0.0.1:5000/api/v1';
+    window.MOOD_API_BASE = MOOD_API_BASE;
     window.API_BASE = CONFIG.API_BASE;
     window.GoogleBooksClient = {
         setKeys(keys) {


### PR DESCRIPTION
# Pull Request

## Description
The public Netlify demo was still calling `http://127.0.0.1:5000/api/v1` from the browser, which triggers loopback/private-network errors on HTTPS and makes the live site look broken in the console.
This PR updates API base resolution so that:
- **Local dev** (`localhost` / `127.0.0.1`) still uses `http://127.0.0.1:5000/api/v1`
- **Public/static hosts** (e.g. Netlify) use **same-origin** `/api/v1` via `window.location.origin`, avoiding loopback requests
- **Chat** no longer forces a localhost API override
- **Netlify builds** can optionally set `MOOD_API_BASE` at build time to inject `window.__MOOD_API_BASE_OVERRIDE__`
- **README** clarifies that the live demo is static-only until a backend is configured
Note: AI/auth features still need a deployed API (or Netlify redirects/proxy to one). This change removes incorrect localhost calls; it does not host the Flask backend on Netlify.

## Related Issue
Fixes #571

## Type of Change
- [x] Bug Fix  
- [ ] Feature  
- [ ] Enhancement  
- [x] Documentation 

## Testing
1. Ran `python3 build_netlify.py` — `dist/` builds successfully.
2. Simulated `resolveMoodApiBase()` for `localhost` → `http://127.0.0.1:5000/api/v1`; for `bibliodrift-dm.netlify.app` → `https://bibliodrift-dm.netlify.app/api/v1` (no `127.0.0.1`).
3. Served `dist/` on `http://127.0.0.1:8765` — `index.html` loads (200); `/api/v1/*` returns 404 on the static server (same-origin, not loopback).
4. Verified optional build override: `MOOD_API_BASE=https://api.example.com/api/v1 python3 build_netlify.py` injects the override correctly.


## Checklist
- [x] Code follows guidelines  
- [x] Tested properly  
- [x] Docs updated  
- [x] PR title includes the relevant event tag or a general contribution label

Contribution for GSSoC'26