### PR TITLE
[GSSoC'26] fix: correct is_production() logic to prevent dev environment being treated as production

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -385,8 +385,7 @@ class Config:
         
         return (
             flask_env == 'production' or 
-            app_env == 'production' or 
-            not self.server.debug
+            app_env == 'production' 
         )
     
     def is_development(self) -> bool:


### PR DESCRIPTION


# Pull Request

This PR is for an open source event GSSoC'26

## Description
Removed not self.server.debug from is_production().The fix will separate "Debug Mode" from "Environment Type," allowing developers to safely test the app with debugging turned off.

## Related Issue
Fixes #656 

## Type of Change
- [x] Bug Fix  
- [ ] Feature  
- [ ] Enhancement  
- [ ] Documentation  

## Testing
Ran existing test suite:
pytest tests/test_env_validation.py -v
Before fix: test_app_accepts_valid_env → FAILED 
After fix: test_app_accepts_valid_env → PASSED 

## Screenshots
Before Testing:
<img width="960" height="46" alt="testing" src="https://github.com/user-attachments/assets/45e6c591-f999-4e08-a841-603baf40a8bb" />
<img width="963" height="20" alt="before testing" src="https://github.com/user-attachments/assets/84820a24-c6dc-4d5e-8d03-500b661a8955" />
 
After Testing:
<img width="957" height="32" alt="after testing" src="https://github.com/user-attachments/assets/e5430f32-33d4-4e6d-9cd7-c0263275f715" />

## Checklist
- [x] Code follows guidelines  
- [x] Tested properly  
- [ ] Docs updated  
- [x] PR title includes the relevant event tag or a general contribution label

