### PR TITLE
[GSSoC] [NSOC] Auto labelling opened PRs with gssoc:approved

### DIFF
--- a/.github/workflows/sync-gssoc-approved-label.yml
+++ b/.github/workflows/sync-gssoc-approved-label.yml
@@ -1,0 +1,99 @@
+name: Sync gssoc approved label
+
+on:
+  pull_request_review:
+    types: [submitted, dismissed]
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  sync-approved-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync gssoc:approved label
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const labelName = 'gssoc:approved';
+            const pullRequest = context.payload.pull_request || context.payload.review?.pull_request;
+
+            if (!pullRequest?.number) {
+              core.info('No pull request context found.');
+              return;
+            }
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pullNumber = pullRequest.number;
+
+            const { data: currentPullRequest } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pullNumber,
+            });
+
+            const headSha = currentPullRequest.head.sha;
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              owner,
+              repo,
+              pull_number: pullNumber,
+              per_page: 100,
+            });
+
+            const latestReviewsByUser = new Map();
+
+            for (const review of reviews) {
+              if (!review.user || review.user.type === 'Bot' || !review.submitted_at) {
+                continue;
+              }
+
+              const existing = latestReviewsByUser.get(review.user.login);
+              const reviewTime = Date.parse(review.submitted_at);
+              const existingTime = existing ? Date.parse(existing.submitted_at) : -1;
+
+              if (!existing || reviewTime >= existingTime) {
+                latestReviewsByUser.set(review.user.login, review);
+              }
+            }
+
+            const approvedOnCurrentHead = [...latestReviewsByUser.values()].some(
+              (review) => review.state === 'APPROVED' && review.commit_id === headSha
+            );
+
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner,
+              repo,
+              issue_number: pullNumber,
+            });
+
+            const hasLabel = labels.some((label) => label.name === labelName);
+
+            if (approvedOnCurrentHead && !hasLabel) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: pullNumber,
+                labels: [labelName],
+              });
+              core.info(`Added ${labelName} to PR #${pullNumber}.`);
+              return;
+            }
+
+            if (!approvedOnCurrentHead && hasLabel) {
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number: pullNumber,
+                name: labelName,
+              });
+              core.info(`Removed ${labelName} from PR #${pullNumber}.`);
+              return;
+            }
+
+            core.info(`No label change needed for PR #${pullNumber}.`);

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -71,6 +71,8 @@ When proposing an enhancement, describe:
 4. Include screenshots for visible UI changes.
 5. Reference the related issue if one exists.
 
+If label automation is enabled in the repository, `gssoc:approved` is added when the PR has an approval on its current head commit and is removed again if that approval becomes stale after new commits.
+
 ## Code Style
 
 - Keep the frontend vanilla unless a change explicitly needs otherwise.


### PR DESCRIPTION
# Pull Request

NSOC and GSSoC

## Description
Implemented the automation in sync-gssoc-approved-label.yml. It watches PR review and PR update events, rechecks the current head commit, and adds or removes gssoc:approved so stale approvals drop off after new commits.

I also added a short contributor note in contributing.md describing when the label is applied and removed. I validated the change with `git diff --check`.

## Related Issue
Fixes #714

## Type of Change
- [ ] Bug Fix  
- [x] Feature  
- [ ] Enhancement  
- [ ] Documentation  



Example:
[NSoC'26] Add authentication system