### PR TITLE
Add password reset flow (API, migration, auth UI)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -59,6 +59,8 @@ from validators import (
     SyncLibraryRequest,
     RegisterRequest,
     LoginRequest,
+    ForgotPasswordRequest,
+    ResetPasswordRequest,
     SetGoalRequest,
     GetStatsRequest,
     CollectionRequest,
@@ -72,9 +74,15 @@ from validators import (
     validate_jwt_secret,
     is_production_mode
 )
+from password_reset_service import (
+    FORGOT_PASSWORD_MESSAGE,
+    request_password_reset,
+    reset_password_with_token,
+)
 from collections import defaultdict, deque
 from math import ceil
 from time import time
+from urllib.parse import quote
 from error_responses import (
     ErrorCodes, error_response, success_response,
     validation_error, missing_fields_error, invalid_json_error,
@@ -1739,6 +1747,75 @@ def logout():
     return resp, status
 
 
+@app.route('/api/v1/auth/forgot-password', methods=['POST'])
+@csrf.exempt
+@limiter.limit("5 per minute")
+def forgot_password():
+    """Request a password reset link (always returns a generic success message)."""
+    try:
+        data = request.get_json(silent=True)
+        if data is None:
+            return invalid_json_error()
+
+        is_valid, validated_data = validate_request(ForgotPasswordRequest, data)
+        if not is_valid:
+            return jsonify(validated_data), 400
+
+        plain_token = None
+        try:
+            plain_token = request_password_reset(validated_data.email)
+        except SQLAlchemyError as e:
+            logger.error("forgot-password database error: %s", e, exc_info=True)
+
+        response_data = {"message": FORGOT_PASSWORD_MESSAGE}
+
+        if plain_token and app_config.is_development():
+            frontend_base = os.getenv(
+                'FRONTEND_ORIGIN',
+                'http://127.0.0.1:5500',
+            ).rstrip('/')
+            response_data["reset_url"] = (
+                f"{frontend_base}/pages/auth.html?token={quote(plain_token)}"
+            )
+            logger.info(
+                "Dev password reset link for %s: %s",
+                validated_data.email,
+                response_data["reset_url"],
+            )
+
+        return success_response(data=response_data)
+    except Exception as e:
+        logger.error("forgot-password failed: %s", e, exc_info=True)
+        return success_response(data={"message": FORGOT_PASSWORD_MESSAGE})
+
+
+@app.route('/api/v1/auth/reset-password', methods=['POST'])
+@csrf.exempt
+@limiter.limit("5 per minute")
+def reset_password():
+    """Set a new password using a valid reset token."""
+    try:
+        data = request.get_json(silent=True)
+        if data is None:
+            return invalid_json_error()
+
+        is_valid, validated_data = validate_request(ResetPasswordRequest, data)
+        if not is_valid:
+            return jsonify(validated_data), 400
+
+        ok, message = reset_password_with_token(
+            validated_data.token,
+            validated_data.password,
+        )
+        if not ok:
+            return jsonify({"error": message}), 400
+
+        return success_response(data={"message": message})
+    except Exception as e:
+        logger.error("reset-password failed: %s", e, exc_info=True)
+        return internal_error("Unable to reset password.")
+
+
 @app.route('/api/v1/auth/verify', methods=['GET'])
 @jwt_required()
 def verify_auth_session():
@@ -2491,6 +2568,8 @@ from validators import (
     SyncLibraryRequest,
     RegisterRequest,
     LoginRequest,
+    ForgotPasswordRequest,
+    ResetPasswordRequest,
     SetGoalRequest,
     GetStatsRequest,
     CollectionRequest,
@@ -2504,9 +2583,15 @@ from validators import (
     validate_jwt_secret,
     is_production_mode
 )
+from password_reset_service import (
+    FORGOT_PASSWORD_MESSAGE,
+    request_password_reset,
+    reset_password_with_token,
+)
 from collections import defaultdict, deque
 from math import ceil
 from time import time
+from urllib.parse import quote
 from error_responses import (
     ErrorCodes, error_response, success_response,
     validation_error, missing_fields_error, invalid_json_error,
@@ -3359,6 +3444,7 @@ def remove_from_library(item_id):
 
 
 db.init_app(app)
+migrate = Migrate(app, db)
 price_tracker = get_price_tracker(db)
 
 
@@ -3737,6 +3823,68 @@ def logout():
     resp, status = success_response(message="Logout successful")
     unset_jwt_cookies(resp)
     return resp, status
+
+
+@app.route('/api/v1/auth/forgot-password', methods=['POST'])
+@limiter.limit("5 per minute")
+def forgot_password():
+    """Request a password reset link (always returns a generic success message)."""
+    try:
+        data = request.get_json(silent=True)
+        if data is None:
+            return invalid_json_error()
+
+        is_valid, validated_data = validate_request(ForgotPasswordRequest, data)
+        if not is_valid:
+            return jsonify(validated_data), 400
+
+        plain_token = request_password_reset(validated_data.email)
+        response_data = {"message": FORGOT_PASSWORD_MESSAGE}
+
+        if plain_token and app_config.is_development():
+            frontend_base = os.getenv(
+                'FRONTEND_ORIGIN',
+                'http://127.0.0.1:5500',
+            ).rstrip('/')
+            response_data["reset_url"] = (
+                f"{frontend_base}/pages/auth.html?token={quote(plain_token)}"
+            )
+            logger.info(
+                "Dev password reset link for %s: %s",
+                validated_data.email,
+                response_data["reset_url"],
+            )
+
+        return success_response(data=response_data)
+    except Exception as e:
+        logger.error("forgot-password failed: %s", e, exc_info=True)
+        return internal_error("Unable to process password reset request.")
+
+
+@app.route('/api/v1/auth/reset-password', methods=['POST'])
+@limiter.limit("5 per minute")
+def reset_password():
+    """Set a new password using a valid reset token."""
+    try:
+        data = request.get_json(silent=True)
+        if data is None:
+            return invalid_json_error()
+
+        is_valid, validated_data = validate_request(ResetPasswordRequest, data)
+        if not is_valid:
+            return jsonify(validated_data), 400
+
+        ok, message = reset_password_with_token(
+            validated_data.token,
+            validated_data.password,
+        )
+        if not ok:
+            return jsonify({"error": message}), 400
+
+        return success_response(data={"message": message})
+    except Exception as e:
+        logger.error("reset-password failed: %s", e, exc_info=True)
+        return internal_error("Unable to reset password.")
 
 
 # ==================== READING STATS ENDPOINTS ====================

--- a/backend/config.py
+++ b/backend/config.py
@@ -165,8 +165,11 @@ class GoogleOAuthConfig:
             client_secret=os.getenv('GOOGLE_CLIENT_SECRET') or os.getenv('GOOGLE_OAUTH_CLIENT_SECRET'),
             redirect_uri=os.getenv('GOOGLE_OAUTH_REDIRECT_URI'),
             frontend_redirect_url=os.getenv('FRONTEND_URL', 'http://127.0.0.1:5500/frontend/pages/library.html'),
-            scope=os.getenv('GOOGLE_OAUTH_SCOPE', 'openid email profile')
-          
+            scope=os.getenv('GOOGLE_OAUTH_SCOPE', 'openid email profile'),
+        )
+
+
+@dataclass
 class EmailConfig:
     """Email service configuration (e.g., SendGrid, Mailgun)."""
     api_key: Optional[str]

--- a/backend/migrations/versions/0004_password_reset_tokens.py
+++ b/backend/migrations/versions/0004_password_reset_tokens.py
@@ -1,0 +1,38 @@
+"""Add password_reset_token table.
+
+Revision ID: 0004
+Revises: 0003
+Create Date: 2026-05-18 12:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '0004'
+down_revision = '0003'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'password_reset_token',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('token_hash', sa.String(length=64), nullable=False),
+        sa.Column('expires_at', sa.DateTime(), nullable=False),
+        sa.Column('used_at', sa.DateTime(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(['user_id'], ['user.id']),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('token_hash'),
+    )
+    op.create_index('ix_password_reset_token_user_id', 'password_reset_token', ['user_id'], unique=False)
+    op.create_index('ix_password_reset_token_token_hash', 'password_reset_token', ['token_hash'], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index('ix_password_reset_token_token_hash', table_name='password_reset_token')
+    op.drop_index('ix_password_reset_token_user_id', table_name='password_reset_token')
+    op.drop_table('password_reset_token')

--- a/backend/models.py
+++ b/backend/models.py
@@ -131,6 +131,19 @@ class User(db.Model, SoftDeleteMixin):
             "is_deleted": self.is_deleted
         }
 
+
+class PasswordResetToken(db.Model):
+    """Single-use token for password reset (stores SHA-256 hash only)."""
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False, index=True)
+    token_hash = db.Column(db.String(64), nullable=False, unique=True, index=True)
+    expires_at = db.Column(db.DateTime, nullable=False)
+    used_at = db.Column(db.DateTime, nullable=True)
+    created_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
+
+    user = db.relationship('User', backref=db.backref('password_reset_tokens', lazy='dynamic'))
+
+
 class Book(db.Model, SoftDeleteMixin):
     query_class = SoftDeleteQuery
     id = db.Column(db.Integer, primary_key=True)

--- a/backend/password_reset_service.py
+++ b/backend/password_reset_service.py
@@ -1,0 +1,101 @@
+"""Password reset token issuance and consumption."""
+import hashlib
+import logging
+import secrets
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from sqlalchemy.exc import SQLAlchemyError
+
+from sqlalchemy import func
+
+try:
+    from .models import PasswordResetToken, User, db
+except ImportError:
+    from models import PasswordResetToken, User, db
+
+logger = logging.getLogger(__name__)
+
+RESET_TOKEN_BYTES = 32
+RESET_TOKEN_TTL = timedelta(hours=1)
+
+FORGOT_PASSWORD_MESSAGE = (
+    "If an account exists for that email, password reset instructions have been sent."
+)
+
+
+def _hash_token(token: str) -> str:
+    return hashlib.sha256(token.encode('utf-8')).hexdigest()
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _invalidate_active_tokens(user_id: int) -> None:
+    now = _utcnow()
+    (
+        PasswordResetToken.query.filter_by(user_id=user_id)
+        .filter(PasswordResetToken.used_at.is_(None))
+        .update({'used_at': now}, synchronize_session=False)
+    )
+
+
+def create_password_reset_token(user: User) -> str:
+    """Create a new reset token for the user; returns the plaintext token."""
+    plain_token = secrets.token_urlsafe(RESET_TOKEN_BYTES)
+    record = PasswordResetToken(
+        user_id=user.id,
+        token_hash=_hash_token(plain_token),
+        expires_at=_utcnow() + RESET_TOKEN_TTL,
+    )
+    _invalidate_active_tokens(user.id)
+    db.session.add(record)
+    db.session.commit()
+    return plain_token
+
+
+def reset_password_with_token(token: str, new_password: str) -> tuple[bool, str]:
+    """Validate token and set a new password. Returns (success, message)."""
+    if not token or not token.strip():
+        return False, "Invalid or expired reset link."
+
+    token_hash = _hash_token(token.strip())
+    record = PasswordResetToken.query.filter_by(token_hash=token_hash).first()
+    now = _utcnow()
+
+    if not record or record.used_at is not None:
+        return False, "Invalid or expired reset link."
+
+    expires = record.expires_at
+    if expires.tzinfo is None:
+        expires = expires.replace(tzinfo=timezone.utc)
+
+    if expires < now:
+        return False, "Invalid or expired reset link."
+
+    user = User.query.get(record.user_id)
+    if not user:
+        return False, "Invalid or expired reset link."
+
+    try:
+        user.set_password(new_password)
+        record.used_at = now
+        db.session.commit()
+        return True, "Password updated successfully. You can sign in with your new password."
+    except SQLAlchemyError as exc:
+        db.session.rollback()
+        logger.error("Password reset failed for user %s: %s", user.id, exc)
+        return False, "Unable to reset password. Please try again later."
+
+
+def request_password_reset(email: str) -> Optional[str]:
+    """
+    Start reset flow for a local account email.
+    Returns plaintext token when a matching user exists, else None.
+    """
+    normalized = email.strip().lower()
+    user = User.query.filter(func.lower(User.email) == normalized).first()
+    if not user:
+        return None
+    return create_password_reset_token(user)

--- a/backend/validators.py
+++ b/backend/validators.py
@@ -202,6 +202,27 @@ class LoginRequest(BaseModel):
     password: str = Field(..., min_length=1, description="Password")
 
 
+class ForgotPasswordRequest(BaseModel):
+    """Request schema for POST /api/v1/auth/forgot-password."""
+    email: EmailStr = Field(..., description="Account email address")
+
+    @field_validator('email')
+    @classmethod
+    def normalize_email(cls, v: str) -> str:
+        return v.strip().lower()
+
+
+class ResetPasswordRequest(BaseModel):
+    """Request schema for POST /api/v1/auth/reset-password."""
+    token: str = Field(..., min_length=16, max_length=256, description="Reset token from email link")
+    password: str = Field(..., min_length=8, max_length=100, description="New password (minimum 8 characters)")
+
+    @field_validator('token')
+    @classmethod
+    def strip_token(cls, v: str) -> str:
+        return v.strip()
+
+
 # ==================== READING STATS & GOALS ====================
 class SetGoalRequest(BaseModel):
     """Request schema for POST /api/v1/stats/goal endpoint."""

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -3941,3 +3941,152 @@ window.addEventListener('offline', handleConnectivityChange);
 
 // Run a status check right away on startup in case the user loads the app while already disconnected
 document.addEventListener('DOMContentLoaded', handleConnectivityChange);
+
+function showForgotResetLink(resetUrl) {
+    const box = document.getElementById('forgotResetLinkBox');
+    if (!box || !resetUrl) return;
+    box.style.display = 'block';
+    box.innerHTML = `
+        <strong>Development reset link</strong> (no email was sent):<br>
+        <a href="${resetUrl}">Open link to set a new password</a>
+    `;
+}
+
+async function handleForgotPassword(event) {
+    if (event) event.preventDefault();
+    const btn = document.getElementById('forgotSubmitBtn');
+    const emailInput = document.getElementById('forgotEmail');
+    const linkBox = document.getElementById('forgotResetLinkBox');
+    const email = emailInput?.value?.trim() || '';
+    const originalText = btn ? btn.textContent : 'Send reset link';
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+        if (typeof showToast === 'function') showToast('Enter a valid email address', 'error');
+        else alert('Enter a valid email address');
+        return;
+    }
+
+    if (linkBox) {
+        linkBox.style.display = 'none';
+        linkBox.innerHTML = '';
+    }
+
+    if (btn) {
+        btn.disabled = true;
+        btn.textContent = 'Sending...';
+    }
+
+    try {
+        const res = await fetch(`${MOOD_API_BASE}/auth/forgot-password`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
+            body: JSON.stringify({ email }),
+        });
+        const data = await res.json();
+        const message = data.message
+            || 'If an account exists for that email, password reset instructions have been sent.';
+
+        if (res.ok) {
+            if (data.reset_url) {
+                showForgotResetLink(data.reset_url);
+                console.info('[Dev] Password reset link:', data.reset_url);
+                if (typeof showToast === 'function') {
+                    showToast('No email sent — use the reset link shown on this page.', 'info');
+                }
+            } else if (typeof showToast === 'function') {
+                showToast(message, 'success');
+            } else {
+                alert(message + '\n\n(No email is sent by the server yet.)');
+            }
+        } else {
+            const err = data.error || data.message || 'Unable to send reset link.';
+            if (typeof showToast === 'function') showToast(err, 'error');
+            else alert(err);
+        }
+    } catch (error) {
+        console.error('Forgot password failed:', error);
+        if (typeof showToast === 'function') {
+            showToast('Could not reach the server. Use http://127.0.0.1:5500 (not file://) and ensure Flask is running.', 'error');
+        } else {
+            alert('Network error. Use http://127.0.0.1:5500 and ensure the backend is running on port 5000.');
+        }
+    } finally {
+        if (btn) {
+            btn.disabled = false;
+            btn.textContent = originalText;
+        }
+    }
+}
+
+window.handleForgotPassword = handleForgotPassword;
+
+async function handleResetPassword(event) {
+    if (event) event.preventDefault();
+    const btn = document.getElementById('resetSubmitBtn');
+    const newPassword = document.getElementById('newPassword')?.value || '';
+    const confirmPassword = document.getElementById('confirmPassword')?.value || '';
+    const token = new URLSearchParams(window.location.search).get('token') || '';
+    const originalText = btn ? btn.textContent : 'Reset password';
+
+    if (newPassword.length < 8) {
+        if (typeof showToast === 'function') showToast('Password must be at least 8 characters.', 'error');
+        else alert('Password must be at least 8 characters.');
+        return;
+    }
+
+    if (newPassword !== confirmPassword) {
+        if (typeof showToast === 'function') showToast('Passwords do not match.', 'error');
+        else alert('Passwords do not match.');
+        return;
+    }
+
+    if (!token) {
+        if (typeof showToast === 'function') showToast('Invalid or missing reset link.', 'error');
+        else alert('Invalid or missing reset link.');
+        return;
+    }
+
+    if (btn) {
+        btn.disabled = true;
+        btn.textContent = 'Updating...';
+    }
+
+    try {
+        const res = await fetch(`${MOOD_API_BASE}/auth/reset-password`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
+            body: JSON.stringify({ token, password: newPassword }),
+        });
+        const data = await res.json();
+        const message = data.message;
+
+        if (res.ok) {
+            if (typeof showToast === 'function') showToast(message || 'Password updated.', 'success');
+            else alert(message || 'Password updated.');
+
+            const url = new URL(window.location.href);
+            url.searchParams.delete('token');
+            setTimeout(() => {
+                window.location.href = url.pathname;
+            }, 1200);
+        } else {
+            const err = data.error || data.message || 'Unable to reset password.';
+            if (typeof showToast === 'function') showToast(err, 'error');
+            else alert(err);
+        }
+    } catch (error) {
+        console.error('Reset password failed:', error);
+        if (typeof showToast === 'function') showToast('Network error. Please try again.', 'error');
+        else alert('Network error. Please try again.');
+    } finally {
+        if (btn) {
+            btn.disabled = false;
+            btn.textContent = originalText;
+        }
+    }
+}
+
+window.handleResetPassword = handleResetPassword;

--- a/frontend/js/auth-password-reset.js
+++ b/frontend/js/auth-password-reset.js
@@ -1,0 +1,177 @@
+/**
+ * Password reset UI for auth.html — self-contained so it does not depend on app.js finishing load.
+ */
+(function () {
+    const apiBase = typeof MOOD_API_BASE !== 'undefined'
+        ? MOOD_API_BASE
+        : 'http://127.0.0.1:5000/api/v1';
+
+    function notify(message, type) {
+        if (typeof showToast === 'function') {
+            showToast(message, type);
+        } else {
+            alert(message);
+        }
+    }
+
+    function showForgotResetLink(resetUrl) {
+        const box = document.getElementById('forgotResetLinkBox');
+        if (!box || !resetUrl) return;
+        box.style.display = 'block';
+        const safeUrl = resetUrl.replace(/"/g, '&quot;');
+        box.innerHTML =
+            '<strong>Development reset link</strong> (no email was sent):<br>' +
+            `<a href="${safeUrl}">Open link to set a new password</a>`;
+    }
+
+    function showForgotResetLinkMissing() {
+        const box = document.getElementById('forgotResetLinkBox');
+        if (!box) return;
+        box.style.display = 'block';
+        box.innerHTML =
+            '<strong>No reset link was generated.</strong><br>' +
+            'Common reasons: this email is not registered yet, or your local database is out of date ' +
+            '(run <code>flask db upgrade</code> in the backend folder). ' +
+            'Register first with this email, then try again. Check the Flask terminal for errors.';
+    }
+
+    async function handleForgotPassword(event) {
+        if (event) event.preventDefault();
+
+        const btn = document.getElementById('forgotSubmitBtn');
+        const emailInput = document.getElementById('forgotEmail');
+        const linkBox = document.getElementById('forgotResetLinkBox');
+        const email = emailInput?.value?.trim() || '';
+        const originalText = btn ? btn.textContent : 'Send reset link';
+
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        if (!emailRegex.test(email)) {
+            notify('Enter a valid email address', 'error');
+            return;
+        }
+
+        if (linkBox) {
+            linkBox.style.display = 'none';
+            linkBox.innerHTML = '';
+        }
+
+        if (btn) {
+            btn.disabled = true;
+            btn.textContent = 'Sending...';
+        }
+
+        try {
+            const res = await fetch(`${apiBase}/auth/forgot-password`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                credentials: 'include',
+                body: JSON.stringify({ email }),
+            });
+            const data = await res.json();
+            const message = data.message
+                || 'If an account exists for that email, password reset instructions have been sent.';
+
+            if (res.ok) {
+                if (data.reset_url) {
+                    showForgotResetLink(data.reset_url);
+                    console.info('[Dev] Password reset link:', data.reset_url);
+                    notify('Use the reset link shown below.', 'info');
+                } else {
+                    showForgotResetLinkMissing();
+                    notify(message, 'success');
+                }
+            } else {
+                notify(data.error || data.message || 'Unable to send reset link.', 'error');
+            }
+        } catch (error) {
+            console.error('Forgot password failed:', error);
+            notify(
+                'Could not reach the server. Use http://127.0.0.1:5500/pages/auth.html (not file://) and ensure Flask is on port 5000.',
+                'error'
+            );
+        } finally {
+            if (btn) {
+                btn.disabled = false;
+                btn.textContent = originalText;
+            }
+        }
+    }
+
+    async function handleResetPassword(event) {
+        if (event) event.preventDefault();
+
+        const btn = document.getElementById('resetSubmitBtn');
+        const newPassword = document.getElementById('newPassword')?.value || '';
+        const confirmPassword = document.getElementById('confirmPassword')?.value || '';
+        const token = new URLSearchParams(window.location.search).get('token') || '';
+        const originalText = btn ? btn.textContent : 'Reset password';
+
+        if (newPassword.length < 8) {
+            notify('Password must be at least 8 characters.', 'error');
+            return;
+        }
+        if (newPassword !== confirmPassword) {
+            notify('Passwords do not match.', 'error');
+            return;
+        }
+        if (!token) {
+            notify('Invalid or missing reset link.', 'error');
+            return;
+        }
+
+        if (btn) {
+            btn.disabled = true;
+            btn.textContent = 'Updating...';
+        }
+
+        try {
+            const res = await fetch(`${apiBase}/auth/reset-password`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                credentials: 'include',
+                body: JSON.stringify({ token, password: newPassword }),
+            });
+            const data = await res.json();
+
+            if (res.ok) {
+                notify(data.message || 'Password updated. You can sign in now.', 'success');
+                const url = new URL(window.location.href);
+                url.searchParams.delete('token');
+                setTimeout(() => {
+                    window.location.href = url.pathname + url.search;
+                }, 1200);
+            } else {
+                notify(data.error || data.message || 'Unable to reset password.', 'error');
+            }
+        } catch (error) {
+            console.error('Reset password failed:', error);
+            notify('Network error. Please try again.', 'error');
+        } finally {
+            if (btn) {
+                btn.disabled = false;
+                btn.textContent = originalText;
+            }
+        }
+    }
+
+    function bindForms() {
+        const forgotForm = document.getElementById('forgotPasswordForm');
+        if (forgotForm) {
+            forgotForm.addEventListener('submit', handleForgotPassword);
+        }
+
+        const resetForm = document.getElementById('resetPasswordForm');
+        if (resetForm) {
+            resetForm.addEventListener('submit', handleResetPassword);
+        }
+    }
+
+    window.handleForgotPassword = handleForgotPassword;
+    window.handleResetPassword = handleResetPassword;
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', bindForms);
+    } else {
+        bindForms();
+    }
+})();

--- a/frontend/pages/auth.html
+++ b/frontend/pages/auth.html
@@ -303,6 +303,38 @@
                 padding: 0.9rem 0.95rem;
             }
         }
+
+        #forgotPasswordPanel,
+        #resetPasswordPanel {
+            display: none;
+        }
+
+        .auth-panel-actions {
+            margin-top: 1rem;
+        }
+
+        .auth-hint {
+            font-size: 0.85rem;
+            color: #666;
+            margin-bottom: 1rem;
+            line-height: 1.4;
+        }
+
+        #forgotResetLinkBox {
+            display: none;
+            margin-top: 1rem;
+            padding: 0.75rem;
+            background: #f5f5f0;
+            border-radius: 6px;
+            text-align: left;
+            font-size: 0.85rem;
+            word-break: break-all;
+        }
+
+        #forgotResetLinkBox a {
+            color: #2c2c2c;
+            font-weight: 600;
+        }
     </style>
     <link rel="icon" href="../assets/images/biblioDrift_favicon.png" type="image/png">
     <!-- PWA -->
@@ -374,6 +406,9 @@
                 <p class="auth-subtitle">Use your account to continue where you left off.</p>
 
                 <form id="authForm" data-mode="login" onsubmit="handleAuth(event)">
+                    <input type="hidden" id="csrf_token" name="csrf_token" value="">
+
+                    
                     <div id="nameField">
                         <input type="text" id="username" class="auth-input" placeholder="Full Name" autocomplete="name">
                     </div>
@@ -386,46 +421,51 @@
                         <input type="password" id="password" class="auth-input" placeholder="Password" value="demo123" required autocomplete="current-password">
                     </div>
 
+                    <span id="forgotPasswordLink" class="toggle-link" style="display: block; margin: -0.25rem 0 1rem; font-size: 0.85rem;">
+                        Forgot password?
+                    </span>
+
                     <button type="submit" id="submitBtn" class="auth-btn">
                         Sign In
                     </button>
+
+                    <button type="button" id="googleAuthBtn" class="google-auth-btn">
+                        <i class="fa-brands fa-google"></i>
+                        <span>Sign in with Google</span>
+                    </button>
                 </form>
+
+                <div id="forgotPasswordPanel">
+                    <p class="auth-hint">
+                        No email is sent yet. In local development, a reset link appears below only if this address is already registered in your database.
+                    </p>
+                    <form id="forgotPasswordForm" action="#" method="post" novalidate>
+                        <input type="email" id="forgotEmail" class="auth-input" placeholder="Email address" required autocomplete="email">
+                        <button type="submit" id="forgotSubmitBtn" class="auth-btn">Send reset link</button>
+                    </form>
+                    <div id="forgotResetLinkBox" aria-live="polite"></div>
+                    
+                    <div class="auth-panel-actions">
+                        <span id="backToSignInFromForgot" class="toggle-link">Back to sign in</span>
+                    </div>
+                </div>
+
+                <div id="resetPasswordPanel">
+                    <form id="resetPasswordForm" action="#" method="post" novalidate>
+                        <input type="password" id="newPassword" class="auth-input" placeholder="New password (min 8 characters)" required minlength="8" autocomplete="new-password">
+                        <input type="password" id="confirmPassword" class="auth-input" placeholder="Confirm new password" required minlength="8" autocomplete="new-password">
+                        <button type="submit" id="resetSubmitBtn" class="auth-btn">Reset password</button>
+                    </form>
+                    <div class="auth-panel-actions">
+                        <span id="backToSignInFromReset" class="toggle-link">Back to sign in</span>
+                    </div>
+                </div>
 
                 <div class="auth-footer">
                     <span id="toggleText" class="toggle-link">
                         No account? Create one.
                     </span>
                 </div>
-                
-                <!-- 
-                    =============================================================
-                    SECURITY COMPLIANCE: CSRF TOKEN FIELD
-                    =============================================================
-                    This hidden input is dynamically populated with a one-time 
-                    security token provided by the backend. It protects against
-                    Cross-Site Request Forgery attacks by ensuring that the 
-                    form submission originated from this specific application 
-                    instance.
-                    =============================================================
-                -->
-                <input type="hidden" id="csrf_token" name="csrf_token" value="">
-                
-                <!-- Primary Action Button -->
-                <button type="submit" id="submitBtn" class="auth-btn">
-                    Sign In
-                </button>
-
-                <button type="button" id="googleAuthBtn" class="google-auth-btn">
-                    <i class="fa-brands fa-google"></i>
-                    <span>Sign in with Google</span>
-                </button>
-            </form>
-            
-            <!-- Mode Toggle Link -->
-            <div class="auth-footer" style="margin-top: 1.5rem;">
-                <span id="toggleText" class="toggle-link">
-                    No account? Create one.
-                </span>
             </div>
         </section>
     </main>
@@ -483,6 +523,7 @@
 
 
     <script src="../js/config.js"></script>
+    <script src="../js/auth-password-reset.js"></script>
     <script src="../js/footer.js"></script>
     <script src="../js/app.js"></script>
     <script src="../script/header-scroll.js"></script>
@@ -503,6 +544,70 @@
             });
         }
         const passwordInput = document.getElementById('password');
+        const forgotPasswordLink = document.getElementById('forgotPasswordLink');
+        const forgotPasswordPanel = document.getElementById('forgotPasswordPanel');
+        const resetPasswordPanel = document.getElementById('resetPasswordPanel');
+        const authFooter = document.querySelector('.auth-footer');
+        const emailInput = document.getElementById('email');
+        const forgotEmailInput = document.getElementById('forgotEmail');
+
+        function showAuthPanel(mode) {
+            const isSignIn = mode === 'signin';
+            authForm.style.display = isSignIn ? 'block' : 'none';
+            if (forgotPasswordPanel) {
+                forgotPasswordPanel.style.display = mode === 'forgot' ? 'block' : 'none';
+            }
+            if (resetPasswordPanel) {
+                resetPasswordPanel.style.display = mode === 'reset' ? 'block' : 'none';
+            }
+            if (authFooter) {
+                authFooter.style.display = isSignIn ? 'block' : 'none';
+            }
+            if (googleAuthBtn) {
+                googleAuthBtn.style.display = isSignIn ? 'flex' : 'none';
+            }
+            if (forgotPasswordLink) {
+                const isLoginMode = isSignIn && authForm.dataset.mode !== 'register';
+                forgotPasswordLink.style.display = isLoginMode ? 'block' : 'none';
+            }
+            if (mode === 'forgot') {
+                authTitle.textContent = 'Reset your password';
+            } else if (mode === 'reset') {
+                authTitle.textContent = 'Choose a new password';
+            } else if (authForm.dataset.mode === 'register') {
+                authTitle.textContent = 'Create Account';
+            } else {
+                authTitle.textContent = 'Welcome Back';
+            }
+        }
+
+        if (forgotPasswordLink) {
+            forgotPasswordLink.addEventListener('click', () => {
+                if (forgotEmailInput && emailInput) {
+                    forgotEmailInput.value = emailInput.value;
+                }
+                const linkBox = document.getElementById('forgotResetLinkBox');
+                if (linkBox) {
+                    linkBox.style.display = 'none';
+                    linkBox.innerHTML = '';
+                }
+                showAuthPanel('forgot');
+            });
+        }
+
+        ['backToSignInFromForgot', 'backToSignInFromReset'].forEach((id) => {
+            const el = document.getElementById(id);
+            if (el) {
+                el.addEventListener('click', () => {
+                    if (window.history.replaceState) {
+                        const url = new URL(window.location.href);
+                        url.searchParams.delete('token');
+                        window.history.replaceState({}, '', url.pathname);
+                    }
+                    showAuthPanel('signin');
+                });
+            }
+        });
 
         if (toggleText) {
             toggleText.addEventListener('click', () => {
@@ -524,7 +629,13 @@
                     toggleText.textContent = 'No account? Create one.';
                     passwordInput.autocomplete = 'current-password';
                 }
+                showAuthPanel('signin');
             });
+        }
+
+        const resetToken = new URLSearchParams(window.location.search).get('token');
+        if (resetToken) {
+            showAuthPanel('reset');
         }
     </script>
     <script src="../js/pwa.js"></script>

--- a/tests/test_password_reset.py
+++ b/tests/test_password_reset.py
@@ -1,0 +1,85 @@
+import os
+import sys
+
+import pytest
+from flask import Flask
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from backend.models import PasswordResetToken, User, db
+from backend.password_reset_service import (
+    create_password_reset_token,
+    request_password_reset,
+    reset_password_with_token,
+)
+
+
+@pytest.fixture(scope='module')
+def flask_app():
+    app = Flask(__name__)
+    app.config.update(
+        TESTING=True,
+        SQLALCHEMY_DATABASE_URI='sqlite:///:memory:',
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+    )
+    db.init_app(app)
+
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture(autouse=True)
+def clean_tables(flask_app):
+    with flask_app.app_context():
+        PasswordResetToken.query.delete()
+        User.query.delete()
+        db.session.commit()
+        yield
+        PasswordResetToken.query.delete()
+        User.query.delete()
+        db.session.commit()
+
+
+def _create_user(email='reader@example.com'):
+    user = User(username='reader', email=email)
+    user.set_password('old-password-1')
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+def test_request_password_reset_returns_token_for_known_email(flask_app):
+    with flask_app.app_context():
+        _create_user()
+        token = request_password_reset('reader@example.com')
+        assert token
+        assert PasswordResetToken.query.count() == 1
+
+
+def test_request_password_reset_unknown_email_returns_none(flask_app):
+    with flask_app.app_context():
+        token = request_password_reset('missing@example.com')
+        assert token is None
+        assert PasswordResetToken.query.count() == 0
+
+
+def test_reset_password_with_valid_token(flask_app):
+    with flask_app.app_context():
+        user = _create_user()
+        plain = create_password_reset_token(user)
+        ok, message = reset_password_with_token(plain, 'new-password-9')
+        assert ok is True
+        assert 'successfully' in message.lower()
+        assert user.check_password('new-password-9')
+
+
+def test_reset_password_rejects_reused_token(flask_app):
+    with flask_app.app_context():
+        user = _create_user()
+        plain = create_password_reset_token(user)
+        assert reset_password_with_token(plain, 'new-password-9')[0] is True
+        ok, _ = reset_password_with_token(plain, 'another-password')
+        assert ok is False


### PR DESCRIPTION
## Description

Adds a password reset flow so users can recover local accounts without sign-up work from #745.

**Backend**
- `POST /api/v1/auth/forgot-password` — accepts email; always returns a generic success message (no email enumeration)
- `POST /api/v1/auth/reset-password` — accepts token + new password
- `PasswordResetToken` model (SHA-256 hashed token, 1-hour expiry, single-use)
- Alembic migration `0004_password_reset_tokens`
- `password_reset_service.py` for token issue/consume logic
- Pydantic validators: `ForgotPasswordRequest`, `ResetPasswordRequest`
- Routes registered on the active Flask app; CSRF exempt for these unauthenticated POST endpoints
- **Development:** `reset_url` in JSON + server log when a matching user exists (`APP_ENV=development`)

**Frontend**
- Forgot password + reset password panels on `auth.html`
- Dedicated `auth-password-reset.js` (does not depend on full `app.js` load)
- Dev reset link shown on page when the API returns `reset_url`; helpful message when no link is generated

**Tests**
- `tests/test_password_reset.py` (service-layer)

**Out of scope (follow-up issue)**
- Real email delivery (SendGrid/SMTP). `.env.example` already has `EMAIL_*` placeholders; no mailer wired yet.

**Note:** `config.py` — fixed a syntax error in `GoogleOAuthConfig.from_env()` (unclosed parenthesis) discovered while running the backend locally.

## Related Issue

Fixes #731 

## Type of Change

- [ ] Bug Fix  
- [x] Feature  
- [ ] Enhancement  
- [ ] Documentation  

## Testing


1. Register a new account with a test email
2. Sign out → **Forgot password?** → submit the same email
3. Confirm dev **reset link** appears below the button (or check Network → `forgot-password` → `reset_url`)
4. Open link → set new password → sign in with new password
5. `pytest tests/test_password_reset.py` (service tests)

## Screenshots

_Add screenshots of: forgot-password panel, dev reset link box, reset-password form (optional)._

## Checklist

- [x] Code follows guidelines  
- [x] Tested properly  
- [ ] Docs updated (not required for this change; email follow-up can document SMTP)  
- [x] PR title includes the relevant event tag or a general contribution label

GSSOC26