### PR TITLE
fix(frontend): add 300ms debounce to search input requests

### DIFF
--- a/frontend/js/library-3d.js
+++ b/frontend/js/library-3d.js
@@ -292,6 +292,17 @@ async function toggleOfflineBook(book, buttonElement) {
         console.error("Failed to alter local shelf cache:", error);
     }
 }
+function debounce(func, delay) {
+    let timeout;
+
+    return function (...args) {
+        clearTimeout(timeout);
+
+        timeout = setTimeout(() => {
+            func.apply(this, args);
+        }, delay);
+    };
+}
 class BookshelfRenderer3D {
     constructor() {
         this.tooltip = document.getElementById('book-tooltip');
@@ -390,14 +401,21 @@ class BookshelfRenderer3D {
 
         // Search listener for "Search for a feeling..."
         const searchInput = document.getElementById('searchInput');
+
         if (searchInput) {
-            this.addManagedListener(searchInput, 'input', (e) => {
-                this.searchQuery = e.target.value.toLowerCase();
+            const debouncedSearch = debounce((value) => {
+                console.log("Debounced fired:", value);
+                this.searchQuery = value.toLowerCase();
+
                 if (this.currentView === 'shelves') {
                     this.refreshShelves();
                 } else {
                     this.renderConstellation();
                 }
+            }, 300);
+
+            this.addManagedListener(searchInput, 'input', (e) => {
+                debouncedSearch(e.target.value);
             });
         }
 


### PR DESCRIPTION
## PR Description

### Related Issue

Closes #245 

### Changes Made

* Added a 300ms debounce mechanism to the search input
* Prevented repeated search execution on every keystroke
* Reduced unnecessary frontend search processing
* Improved typing responsiveness and overall UX

### Implementation Details

* Added a reusable `debounce()` utility function
* Wrapped the search input handler with debounce logic
* Triggered search updates only after the user stops typing for 300ms

### Testing

* Verified that rapid typing triggers only a single debounced execution
* Confirmed reduced repeated search handling during input
* Tested functionality on the library search page
