### PR TITLE
Fix stale logged-in UI when auth verify fails on network error

### DIFF
--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -323,9 +323,8 @@ async function verifyStoredAuthSession() {
             }
 
             const response = await fetch(`${MOOD_API_BASE}/auth/verify`, {
-                credentials: 'include',
-                headers,
                 method: 'GET',
+                headers,
                 credentials: 'include',
             });
 
@@ -344,8 +343,9 @@ async function verifyStoredAuthSession() {
             }
             return null;
         } catch (error) {
-            console.warn('Auth verification failed; using cached session state if available.', error);
-            return storedUser;
+            console.warn('Auth verification could not reach the server; clearing local session.', error);
+            clearStoredAuthState();
+            return null;
         }
     })();
 


### PR DESCRIPTION
## Description

After a successful login, the app stores `bibliodrift_user` and `isLoggedIn` in local storage and runs `verifyStoredAuthSession()` on page load to validate the current session through `GET /api/v1/auth/verify`.

Previously, if the verification request failed because the backend was unreachable (backend stopped, offline mode, CORS issue, wrong origin, etc.), the app would still fall back to the cached `storedUser` from local storage. This caused the navbar to continue showing logged-in UI even though the session was never verified.

This PR updates `verifyStoredAuthSession()` in `frontend/js/app.js` so failed verification requests are treated the same as invalid sessions.

### What changed

- Clear stored auth data when session verification fails
- Return `null` instead of using cached session state
- Show signed-out navigation until verification succeeds again
- Keep behavior consistent with existing `401` / `422` handling
- Remove the duplicate `credentials: 'include'` entry from the same `fetch` call

## Related Issue

Fixes #730 

## Type of Change

- [x] Bug Fix
- [ ] Feature
- [ ] Enhancement
- [ ] Documentation

## Testing

1. Serve the frontend over HTTP
2. Start the Flask backend
3. Register or log in with a real account (not `demo@bibliodrift.com`)
4. Confirm:
   - Logged-in navigation is visible
   - `bibliodrift_user` and `isLoggedIn` exist in local storage
5. Stop the backend (or enable DevTools → Network → Offline)
6. Reload `index.html` or `library.html`

### Expected Result

- Navbar shows signed-out navigation
- Local auth keys are cleared
- Console warns that session verification failed
- Cached session state is no longer used

7. Restart the backend and reload the page
8. User should be required to sign in again

## Screenshots

_Optional: before/after navbar state when backend is unavailable._

## Checklist

- [x] Code follows project guidelines
- [x] Tested locally
- [ ] Documentation updated (not required)
- [x] PR title includes the appropriate contribution tag