### PR TITLE
[NSOC'26][GSSOC'26]Feat: implement centralized Publish-Subscribe state store

### DIFF
--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -84,6 +84,33 @@ const moodAnalysisCache = new Map();
 
 const delay = (ms) => new Promise((res) => setTimeout(res, ms));
 
+/**
+ * Centralized Publish-Subscribe State Store
+ */
+class Store {
+    constructor(initialState = {}) {
+        this.state = initialState;
+        this.listeners = [];
+    }
+    getState() { return this.state; }
+    setState(updater) {
+        const newState = typeof updater === 'function' ? updater(this.state) : updater;
+        this.state = { ...this.state, ...newState };
+        this.notify();
+    }
+    subscribe(listener) {
+        this.listeners.push(listener);
+        return () => { this.listeners = this.listeners.filter(l => l !== listener); };
+    }
+    notify() { this.listeners.forEach(listener => listener(this.state)); }
+}
+
+window.appStore = new Store({
+    user: null,
+    libraryBooks: { current: [], want: [], finished: [] },
+    currentTheme: localStorage.getItem('bibliodrift_theme') || 'light'
+});
+
 let GOOGLE_API_KEY = '';
 
 /**
@@ -260,6 +287,7 @@ function clearStoredAuthState() {
     SafeStorage.remove('bibliodrift_user');
     SafeStorage.remove('bibliodrift_token');
     SafeStorage.remove('isLoggedIn');
+    window.appStore.setState({ user: null });
     authSessionPromise = null;
 }
 
@@ -334,6 +362,7 @@ async function verifyStoredAuthSession() {
                 const verifiedUser = data.user || storedUser;
                 if (verifiedUser) {
                     SafeStorage.set('bibliodrift_user', JSON.stringify(verifiedUser));
+                    window.appStore.setState({ user: verifiedUser });
                 }
                 SafeStorage.set('isLoggedIn', 'true');
                 return verifiedUser || null;

--- a/frontend/js/theme-manager.js
+++ b/frontend/js/theme-manager.js
@@ -163,6 +163,7 @@ function setTheme(themeName) {
     
     // Store mood theme separately so we don't break the light/dark mode preference!
     localStorage.setItem("bibliodrift_mood", themeName);
+    if (window.appStore) window.appStore.setState({ currentTheme: themeName });
 }
 
 /**


### PR DESCRIPTION
Closes #871 

This PR introduces a lightweight, centralized Publish-Subscribe (PubSub) state store in Vanilla JS to address fragmented state management.

**Changes:**
- Implemented `Store` class globally as `window.appStore` within `app.js`.
- Initialized core application states: `user`, `libraryBooks`, and `currentTheme`.
- Integrated `appStore.setState` into existing authentication and theme mutators to maintain a single source of truth.
- Kept the implementation backwards-compatible to prevent breaking existing components, allowing progressive adoption of `.subscribe()` for automatic UI re-rendering in follow-up work.
