### PR TITLE
[GSSoc'26] Added fallback UI for no search results

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -6810,4 +6810,72 @@ body.night-mode .tooltip-author {
     border-color: var(--text-main);
 }
 
-
+/* ── No-results empty state ── */
+#no-results-state {
+  justify-content: center;
+  align-items: center;
+  padding: 3rem 1.5rem;
+}
+.no-results-inner {
+  text-align: center;
+  max-width: 480px;
+  width: 100%;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 1.5rem;
+  padding: 2.75rem 2rem;
+}
+.no-results-icon-wrap {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto 1.25rem;
+  font-size: 1.75rem;
+}
+.no-results-title {
+  font-family: 'Playfair Display', Georgia, serif;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--text-main, #f0ece3);
+  margin: 0 0 0.5rem;
+}
+.no-results-subtitle {
+  font-size: 0.875rem;
+  color: var(--text-muted, #a89f91);
+  margin: 0 0 0.5rem;
+  line-height: 1.6;
+}
+.no-results-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted, #a89f91);
+  margin: 0 0 0.75rem;
+}
+.no-results-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: center;
+}
+.mood-suggestion-tag {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgb(0, 0, 0);
+  color: var(--text-main, #2810b1ce);
+  border-radius: 20rem;
+  padding: 0.4rem 1rem;
+  font-size: 0.95rem;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 0.15s ease, transform 0.15s ease, border-color 0.15s ease;
+}
+.mood-suggestion-tag:hover {
+  background: rgba(255, 255, 255, 0.13);
+  border-color: rgba(255, 255, 255, 0.25);
+  transform: translateY(-2px);
+}

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -82,6 +82,17 @@
 const IS_DEV = typeof window !== 'undefined' && ['localhost', '127.0.0.1'].includes(window.location.hostname);
 const moodAnalysisCache = new Map();
 
+
+// ── No-results empty state helpers ──
+function showNoResults() {
+  const el = document.getElementById('no-results-state');
+  if (el) el.style.display = 'flex';
+}
+function hideNoResults() {
+  const el = document.getElementById('no-results-state');
+  if (el) el.style.display = 'none';
+}
+
 const delay = (ms) => new Promise((res) => setTimeout(res, ms));
 
 let GOOGLE_API_KEY = '';
@@ -1430,8 +1441,10 @@ class BookRenderer {
                 await this.renderBookCards(container, data.items.slice(0, maxResults));
             } else {
                 const fallbackBooks = getFallbackBooks(query, maxResults);
-                if (fallbackBooks.length > 0) {
+                if (fallbackBooks.length > 0 && container.id !== 'search-results-grid') {
                     await this.renderBookCards(container, fallbackBooks);
+                } else if (container.id === 'search-results-grid') {
+                    showNoResults();
                 } else {
                     container.innerHTML = `
                         <div class="empty-state">
@@ -1443,19 +1456,15 @@ class BookRenderer {
         } catch (err) {
             console.error("Failed to fetch books", err);
             const fallbackBooks = getFallbackBooks(query, maxResults);
-            if (fallbackBooks.length > 0) {
+            if (fallbackBooks.length > 0 && container.id !== 'search-results-grid') {
                 await this.renderBookCards(container, fallbackBooks);
                 return;
+            } else if (container.id === 'search-results-grid') {
+                showNoResults();
+                return;
             }
-
-            showToast("Failed to load bookshelf.", "error");
-            container.innerHTML = `
-                <div class="empty-state">
-                    <i class="fa-solid fa-triangle-exclamation"></i>
-                    <p>Bookshelf Empty (API connection failed)</p>
-                </div>`;
-        }
     }
+}
 
     async renderMoodCategorySection(categoryConfig, elementId, maxResults = 5) {
         const container = document.getElementById(elementId);
@@ -1539,6 +1548,11 @@ class BookRenderer {
 
     async renderBookCards(container, books) {
         if (container.id === 'search-results-grid') {
+            if (!books || books.length === 0) {
+                showNoResults();
+                return;
+            }
+            hideNoResults();
             window.searchFilterManager = new SearchFilterManager(container, books, this);
             return;
         }
@@ -1565,6 +1579,8 @@ class BookRenderer {
         if (container.children.length === 0) {
             container.innerHTML = '<p class="empty-state">Failed to load books. Please check your connection.</p>';
         }
+
+        
     }
 }
 
@@ -2902,6 +2918,17 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     const genreManager = new GenreManager(libManager);
     genreManager.init();
+
+    // ── No-results suggestion tag clicks ──
+    document.querySelectorAll('.mood-suggestion-tag').forEach(btn => {
+    btn.addEventListener('click', () => {
+        const input = document.getElementById('searchInput');
+        if (!input) return;
+        input.value = btn.dataset.mood;
+        window.location.href = `index.html?q=${encodeURIComponent(btn.dataset.mood)}`;
+    });
+    });
+
     const exportBtn = document.getElementById("export-library");
     if (exportBtn) {
         const isLibraryPage = document.getElementById("shelf-want");

--- a/frontend/pages/index.html
+++ b/frontend/pages/index.html
@@ -160,7 +160,22 @@
       <div class="curated-row" id="search-results-grid">
         <!-- Dynamically Appended Books -->
       </div>
-    </section>
+      <!-- NO-RESULTS EMPTY STATE -->
+      <div id="no-results-state" role="status" aria-live="polite" style="display:none;">
+      <div class="no-results-inner">
+        <div class="no-results-icon-wrap">📭</div>
+        <h3 class="no-results-title">No books found for this vibe.</h3>
+        <p class="no-results-subtitle">The shelves came up empty — try drifting somewhere else.</p>
+        <p class="no-results-label">Try one of these vibes</p>
+        <div class="no-results-tags">
+          <button class="mood-suggestion-tag" data-mood="rainy mystery">🌧️ rainy mystery</button>
+          <button class="mood-suggestion-tag" data-mood="cozy fantasy">🍂 cozy fantasy</button>
+          <button class="mood-suggestion-tag" data-mood="hopeful adventure">✨ hopeful adventure</button>
+          <button class="mood-suggestion-tag" data-mood="quiet heartbreak">🌙 quiet heartbreak</button>
+          <button class="mood-suggestion-tag" data-mood="dark academia">🕯️ dark academia</button>
+        </div>
+      </div>
+    </div>
 
     <!-- Curated Sections -->
     <section class="curated-section">


### PR DESCRIPTION
# Pull Request
GSSoC

## Description
Added a fallback UI for empty search/vibe results. Instead of showing a blank screen, users now see a friendly empty state with the message **"No books found for this vibe"**, a short subtext, and **5 suggested vibe chips** (rainy mystery, cozy fantasy, hopeful adventure, quiet heartbreak, dark academia) so users can immediately explore other options.

## Related Issue
Fixes #553 

## Type of Change
- [x] Bug Fix
- [ ] Feature
- [x] Enhancement
- [ ] Documentation

## Testing
- Triggered the empty state by searching for a vibe/query that returns no results
- Verified the fallback UI renders correctly with the illustration, message, and vibe suggestion chips
- Clicked each suggested vibe chip to confirm they redirect/trigger a new search correctly
- Tested on both desktop and mobile viewports

## Screenshots
BEFORE
<img width="1876" height="671" alt="image" src="https://github.com/user-attachments/assets/7d53dabe-4468-4b51-9e82-93efeb2137dc" />

AFTER
<img width="1899" height="819" alt="image" src="https://github.com/user-attachments/assets/78350519-d6d6-4d68-9ae0-1e190c77f552" />


## Checklist
- [x] Code follows guidelines
- [x] Tested properly
- [ ] Docs updated
- [x] PR title includes the relevant event tag or a general contribution label