### PR TITLE
[GSSoC'26] fix: silent auth failure in auth_headers + add admin fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,10 +84,32 @@ def auth_headers(client, test_user):
         "/api/auth/login",
         json={"username": "testuser", "password": "Password123!"},
     )
-    token = resp.get_json().get("access_token", "")
-    return {"Authorization": f"Bearer {token}"}
+    data = resp.get_json()
+    assert resp.status_code == 200, f"Login failed: {data}"
+    assert "access_token" in data, f"No token in response: {data}"
+    return {"Authorization": f"Bearer {data['access_token']}"}
+
+@pytest.fixture
+def admin_user(app):
+    with app.app_context():
+        admin = User(username="adminuser", email="admin@example.com", is_admin=True)
+        admin.set_password("AdminPass123!")
+        _db.session.add(admin)
+        _db.session.commit()
+        _db.session.refresh(admin)
+        return admin
 
 
+@pytest.fixture
+def admin_auth_headers(client, admin_user):
+    resp = client.post(
+        "/api/auth/login",
+        json={"username": "adminuser", "password": "AdminPass123!"},
+    )
+    data = resp.get_json()
+    assert resp.status_code == 200, f"Admin login failed: {data}"
+    assert "access_token" in data, f"No token in response: {data}"
+    return {"Authorization": f"Bearer {data['access_token']}"}
 # --- Mocks for external services (issue #511 requirement) ---
 
 @pytest.fixture


### PR DESCRIPTION
## Description
Fixes silent empty Bearer token in `auth_headers` fixture when login fails.
Adds `admin_user` and `admin_auth_headers` fixtures for role-based route testing.

Changes in `tests/conftest.py`:
- Added assert on status code and token in `auth_headers`
- Added `admin_user` fixture with is_admin=True
- Added `admin_auth_headers` fixture with fail-fast assert pattern

## Related Issue
Fixes #991  

## Type of Change
- [ ] Bug Fix  
- [x] Enhancement  
- [ ] Feature  
- [ ] Documentation  

## Testing
- Verified auth_headers raises AssertionError with clear message when login fails
- Verified admin_user is created successfully in the test DB
- Verified admin_auth_headers returns a valid Bearer token
- Ran full test suite with pytest — no regressions

## Screenshots
N/A

## Checklist
- [x] Code follows guidelines  
- [x] Tested properly  
- [x] Docs updated  
- [x] PR title includes the relevant event tag or a general contribution label