### PR TITLE
[GSSoC'26] fix: rename quiz mood-tags class to avoid overlap with book cover tags

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -7074,7 +7074,7 @@ body.night-mode .tooltip-author {
     margin-bottom: 1rem;
 }
 
-.mood-tags {
+.quiz-mood-tags {
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
@@ -7082,7 +7082,7 @@ body.night-mode .tooltip-author {
     margin-bottom: 1.5rem;
 }
 
-.mood-tags span {
+.quiz-mood-tags span {
     background: var(--glass-bg);
     border: 1px solid var(--accent-gold);
     color: var(--accent-gold);

--- a/frontend/pages/app.html
+++ b/frontend/pages/app.html
@@ -425,7 +425,7 @@
 
         <div class="quiz-results" id="quizResults" hidden>
           <h3>Your Reading Mood Tags</h3>
-          <div class="mood-tags" id="moodTags"></div>
+          <div class="quiz-mood-tags" id="moodTags"></div>
           <button type="button" id="retakeQuiz" class="retake-quiz-btn">
             Retake Quiz
           </button>


### PR DESCRIPTION
# Pull Request

## Description
Renamed the quiz-specific `.mood-tags` CSS class to `.quiz-mood-tags` to prevent style conflict with the book cover mood tags class.
Changes made:
- `frontend/css/style.css`: Renamed `.mood-tags` and `.mood-tags span` 
  to `.quiz-mood-tags` and `.quiz-mood-tags span` in the quiz results section
- `frontend/pages/app.html`: Updated the div class from `mood-tags` 
  to `quiz-mood-tags` in the quiz results section

## Related Issue
Fixes #927 

## Type of Change
- [x] Bug Fix  
- [ ] Feature  
- [ ] Enhancement  
- [ ] Documentation

## Testing
1. Opened frontend/pages/app.html in browser
2. Navigated to the Reading Mood Quiz section
3. Selected options across all quiz questions
4. Clicked Generate Tags
5. Verified hashtag tags appear correctly inside the 
   quiz results box without overlapping any other content

## Screenshots
<img width="1913" height="967" alt="image" src="https://github.com/user-attachments/assets/1a52c7f5-7226-4858-ad0a-26a43687e0b1" />

## Checklist
- [x] Code follows guidelines  
- [x] Tested properly  
- [ ] Docs updated  
- [x] PR title includes the relevant event tag or a general contribution label
