### PR TITLE
fix: add local dev server setup to fix CORS fetch error (fixes #494)

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,10 +208,21 @@ This ensures discovery stays organic, scalable, and aligned with BiblioDrift’s
    bash
    git clone https://github.com/devanshi14malhotra/bibliodrift.git
    
-2. Open index.html in your browser.
-   - That's it! No build steps required for the vanilla frontend.
+2. Serve the frontend using a local HTTP server (do NOT open HTML files directly in the browser):
+```bash
+   cd frontend
+   python -m http.server 8080
+```
+3. Start the backend:
+```bash
+   cd backend
+   python app.py
+```
+4. Open `http://localhost:8080/pages/auth.html` in your browser.
 
-### Backend
+> ⚠️ **Important:** Opening HTML files directly via `file:///` URLs will cause a CORS error (`TypeError: Failed to fetch`) because the browser blocks all fetch requests from a `null` origin. Always use a local server.
+
+### Backend 
 The Flask backend powers authentication, library sync, AI blurbs, chat, mood analysis, and other API flows.
 
 ## 🚢 Deployment Notes


### PR DESCRIPTION
## Problem
Opening `auth.html` directly as a `file:///` URL gives the page a `null` 
origin. The browser blocks all fetch() requests from a null origin due to 
CORS policy, causing `TypeError: Failed to fetch` on Create Account.

## Root Cause
The README instructed users to "Open index.html in your browser directly" 
which causes the CORS block before requests even reach the Flask backend.

## Fix
Updated README installation steps to serve the frontend via a local HTTP 
server instead of opening files directly.

##Screenshot
<img width="1919" height="1094" alt="Screenshot 2026-05-25 123503" src="https://github.com/user-attachments/assets/4b266435-9906-43ec-97b5-cfb94209197a" />

## Testing
1. Run `cd backend && python app.py`
2. Run `cd frontend && python -m http.server 8080`  
3. Open `http://localhost:8080/pages/auth.html`
4. Create Account works successfully ✅

Fixes #494