### PR TITLE
feat(auth): send password reset emails via SendGrid or SMTP

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -80,10 +80,14 @@ from password_reset_service import (
     request_password_reset,
     reset_password_with_token,
 )
+from email_service import (
+    build_password_reset_url,
+    is_email_configured,
+    send_password_reset_email,
+)
 from collections import defaultdict, deque
 from math import ceil
 from time import time
-from urllib.parse import quote
 from error_responses import (
     ErrorCodes, error_response, success_response,
     validation_error, missing_fields_error, invalid_json_error,
@@ -1874,20 +1878,36 @@ def forgot_password():
             logger.error("forgot-password database error: %s", e, exc_info=True)
 
         response_data = {"message": FORGOT_PASSWORD_MESSAGE}
+        frontend_base = os.getenv('FRONTEND_ORIGIN', 'http://127.0.0.1:5500').rstrip('/')
+        email_config = app_config.email
 
-        if plain_token and app_config.is_development():
-            frontend_base = os.getenv(
-                'FRONTEND_ORIGIN',
-                'http://127.0.0.1:5500',
-            ).rstrip('/')
-            response_data["reset_url"] = (
-                f"{frontend_base}/pages/auth.html?token={quote(plain_token)}"
-            )
-            logger.info(
-                "Dev password reset link for %s: %s",
-                validated_data.email,
-                response_data["reset_url"],
-            )
+        if plain_token:
+            reset_url = build_password_reset_url(plain_token, frontend_base)
+            if is_email_configured(email_config):
+                send_result = send_password_reset_email(
+                    validated_data.email,
+                    reset_url,
+                    email_config,
+                )
+                if not send_result.ok:
+                    logger.error(
+                        "Password reset email not sent for %s: %s",
+                        validated_data.email,
+                        send_result.detail,
+                    )
+            elif app_config.is_development():
+                response_data["reset_url"] = reset_url
+                logger.info(
+                    "Dev password reset link for %s (email not configured): %s",
+                    validated_data.email,
+                    reset_url,
+                )
+            elif app_config.is_production():
+                logger.warning(
+                    "Password reset token created but EMAIL_* is not configured; "
+                    "user %s will not receive mail.",
+                    validated_data.email,
+                )
 
         return success_response(data=response_data)
     except Exception as e:

--- a/backend/config.py
+++ b/backend/config.py
@@ -170,18 +170,28 @@ class GoogleOAuthConfig:
 
 @dataclass
 class EmailConfig:
-    """Email service configuration (e.g., SendGrid, Mailgun)."""
+    """Email service configuration (SendGrid API or SMTP)."""
     api_key: Optional[str]
     from_email: Optional[str]
     service_provider: str = 'sendgrid'
-    
+    smtp_host: Optional[str] = None
+    smtp_port: int = 587
+    smtp_username: Optional[str] = None
+    smtp_password: Optional[str] = None
+    smtp_use_tls: bool = True
+
     @classmethod
     def from_env(cls) -> 'EmailConfig':
         """Create email config from environment variables."""
         return cls(
             api_key=os.getenv('EMAIL_API_KEY'),
             from_email=os.getenv('EMAIL_FROM'),
-            service_provider=os.getenv('EMAIL_SERVICE', 'sendgrid')
+            service_provider=os.getenv('EMAIL_SERVICE', 'sendgrid'),
+            smtp_host=os.getenv('EMAIL_SMTP_HOST'),
+            smtp_port=int(os.getenv('EMAIL_SMTP_PORT', '587')),
+            smtp_username=os.getenv('EMAIL_SMTP_USER'),
+            smtp_password=os.getenv('EMAIL_SMTP_PASSWORD'),
+            smtp_use_tls=os.getenv('EMAIL_SMTP_USE_TLS', 'true').lower() == 'true',
         )
 
 

--- a/backend/email_service.py
+++ b/backend/email_service.py
@@ -1,0 +1,171 @@
+"""Outbound email delivery for password reset and other transactional mail."""
+from __future__ import annotations
+
+import logging
+import smtplib
+from dataclasses import dataclass
+from email.message import EmailMessage
+from typing import Optional
+from urllib.parse import quote
+
+import requests
+
+try:
+    from .config import EmailConfig
+except ImportError:
+    from config import EmailConfig
+
+logger = logging.getLogger(__name__)
+
+SENDGRID_API_URL = 'https://api.sendgrid.com/v3/mail/send'
+PASSWORD_RESET_SUBJECT = 'Reset your BiblioDrift password'
+
+
+@dataclass(frozen=True)
+class EmailSendResult:
+    """Result of an email send attempt."""
+
+    ok: bool
+    detail: str = ''
+
+
+def is_email_configured(config: EmailConfig) -> bool:
+    """Return True when enough settings exist to send mail for the chosen provider."""
+    if not config.from_email or not str(config.from_email).strip():
+        return False
+
+    provider = (config.service_provider or 'sendgrid').strip().lower()
+    if provider == 'sendgrid':
+        return bool(config.api_key and str(config.api_key).strip())
+    if provider == 'smtp':
+        return bool(config.smtp_host and str(config.smtp_host).strip())
+    logger.warning("Unknown EMAIL_SERVICE '%s'; email disabled.", provider)
+    return False
+
+
+def build_password_reset_url(plain_token: str, frontend_origin: str) -> str:
+    """Build the frontend URL users open to set a new password."""
+    base = (frontend_origin or 'http://127.0.0.1:5500').rstrip('/')
+    return f"{base}/pages/auth.html?token={quote(plain_token, safe='')}"
+
+
+def _password_reset_bodies(reset_url: str) -> tuple[str, str]:
+    text = (
+        'You requested a password reset for your BiblioDrift account.\n\n'
+        f'Open this link to choose a new password (valid for 1 hour):\n{reset_url}\n\n'
+        'If you did not request this, you can ignore this email.'
+    )
+    html = (
+        '<p>You requested a password reset for your <strong>BiblioDrift</strong> account.</p>'
+        f'<p><a href="{reset_url}">Reset your password</a> (link expires in 1 hour).</p>'
+        '<p>If you did not request this, you can ignore this email.</p>'
+    )
+    return text, html
+
+
+def send_password_reset_email(
+    to_email: str,
+    reset_url: str,
+    config: EmailConfig,
+) -> EmailSendResult:
+    """Send the password reset message. Does not raise on provider errors."""
+    if not is_email_configured(config):
+        return EmailSendResult(ok=False, detail='email_not_configured')
+
+    text_body, html_body = _password_reset_bodies(reset_url)
+    provider = (config.service_provider or 'sendgrid').strip().lower()
+
+    try:
+        if provider == 'sendgrid':
+            return _send_via_sendgrid(
+                to_email=to_email,
+                subject=PASSWORD_RESET_SUBJECT,
+                text_body=text_body,
+                html_body=html_body,
+                config=config,
+            )
+        if provider == 'smtp':
+            return _send_via_smtp(
+                to_email=to_email,
+                subject=PASSWORD_RESET_SUBJECT,
+                text_body=text_body,
+                html_body=html_body,
+                config=config,
+            )
+        return EmailSendResult(ok=False, detail=f'unsupported_provider:{provider}')
+    except Exception as exc:
+        logger.error('Password reset email failed for %s: %s', to_email, exc, exc_info=True)
+        return EmailSendResult(ok=False, detail=str(exc))
+
+
+def _send_via_sendgrid(
+    *,
+    to_email: str,
+    subject: str,
+    text_body: str,
+    html_body: str,
+    config: EmailConfig,
+) -> EmailSendResult:
+    payload = {
+        'personalizations': [{'to': [{'email': to_email}]}],
+        'from': {'email': config.from_email},
+        'subject': subject,
+        'content': [
+            {'type': 'text/plain', 'value': text_body},
+            {'type': 'text/html', 'value': html_body},
+        ],
+    }
+    response = requests.post(
+        SENDGRID_API_URL,
+        headers={
+            'Authorization': f'Bearer {config.api_key}',
+            'Content-Type': 'application/json',
+        },
+        json=payload,
+        timeout=15,
+    )
+    if response.status_code in (200, 202):
+        return EmailSendResult(ok=True)
+    logger.error(
+        'SendGrid rejected mail to %s: HTTP %s %s',
+        to_email,
+        response.status_code,
+        response.text[:500],
+    )
+    return EmailSendResult(ok=False, detail=f'sendgrid_http_{response.status_code}')
+
+
+def _send_via_smtp(
+    *,
+    to_email: str,
+    subject: str,
+    text_body: str,
+    html_body: str,
+    config: EmailConfig,
+) -> EmailSendResult:
+    message = EmailMessage()
+    message['Subject'] = subject
+    message['From'] = config.from_email
+    message['To'] = to_email
+    message.set_content(text_body)
+    message.add_alternative(html_body, subtype='html')
+
+    host = config.smtp_host
+    port = config.smtp_port
+    use_tls = config.smtp_use_tls
+
+    if use_tls:
+        with smtplib.SMTP(host, port, timeout=15) as smtp:
+            smtp.ehlo()
+            smtp.starttls()
+            smtp.ehlo()
+            if config.smtp_username and config.smtp_password:
+                smtp.login(config.smtp_username, config.smtp_password)
+            smtp.send_message(message)
+    else:
+        with smtplib.SMTP(host, port, timeout=15) as smtp:
+            if config.smtp_username and config.smtp_password:
+                smtp.login(config.smtp_username, config.smtp_password)
+            smtp.send_message(message)
+
+    return EmailSendResult(ok=True)

--- a/config/.env.example
+++ b/config/.env.example
@@ -40,10 +40,19 @@ OPENAI_API_KEY=your-openai-api-key
 GROQ_API_KEY=your-groq-api-key
 GEMINI_API_KEY=your-gemini-api-key
 
-# Email Service Configuration
+# Email Service Configuration (password reset and transactional mail)
+# EMAIL_SERVICE: sendgrid | smtp
 EMAIL_SERVICE=sendgrid
-EMAIL_API_KEY=your-email-api-key
+EMAIL_API_KEY=your-sendgrid-api-key
 EMAIL_FROM=noreply@bibliodrift.com
+# SMTP (when EMAIL_SERVICE=smtp)
+EMAIL_SMTP_HOST=smtp.example.com
+EMAIL_SMTP_PORT=587
+EMAIL_SMTP_USER=
+EMAIL_SMTP_PASSWORD=
+EMAIL_SMTP_USE_TLS=true
+# Base URL for links in emails (no trailing slash)
+FRONTEND_ORIGIN=http://127.0.0.1:5500
 
 # External Storage Configuration
 STORAGE_ACCESS_KEY=your-storage-access-key

--- a/frontend/js/auth-password-reset.js
+++ b/frontend/js/auth-password-reset.js
@@ -72,12 +72,15 @@
                 || 'If an account exists for that email, password reset instructions have been sent.';
 
             if (res.ok) {
+                const isLocalDev = ['localhost', '127.0.0.1'].includes(window.location.hostname);
                 if (data.reset_url) {
                     showForgotResetLink(data.reset_url);
                     console.info('[Dev] Password reset link:', data.reset_url);
                     notify('Use the reset link shown below.', 'info');
-                } else {
+                } else if (isLocalDev) {
                     showForgotResetLinkMissing();
+                    notify(message, 'success');
+                } else {
                     notify(message, 'success');
                 }
             } else {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,8 +36,8 @@ os.environ.setdefault("GROQ_API_KEY", "fake-groq-key")
 os.environ.setdefault("GEMINI_API_KEY", "fake-gemini-key")
 os.environ.setdefault("FLASK_ENV", "testing")
 
-from backend.app import app as flask_app
-from backend.models import db as _db, User
+from backend.app import app as flask_app, db as _db
+from backend.models import User
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_email_service.py
+++ b/tests/test_email_service.py
@@ -1,0 +1,103 @@
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from backend.config import EmailConfig
+from backend.email_service import (
+    build_password_reset_url,
+    is_email_configured,
+    send_password_reset_email,
+)
+
+
+def test_build_password_reset_url_encodes_token():
+    url = build_password_reset_url('abc+def/token', 'http://127.0.0.1:5500/')
+    assert url.startswith('http://127.0.0.1:5500/pages/auth.html?token=')
+    assert 'abc%2Bdef%2Ftoken' in url
+
+
+def test_is_email_configured_sendgrid():
+    cfg = EmailConfig(
+        api_key='sg-key',
+        from_email='noreply@example.com',
+        service_provider='sendgrid',
+    )
+    assert is_email_configured(cfg) is True
+
+
+def test_is_email_configured_sendgrid_missing_key():
+    cfg = EmailConfig(
+        api_key=None,
+        from_email='noreply@example.com',
+        service_provider='sendgrid',
+    )
+    assert is_email_configured(cfg) is False
+
+
+def test_is_email_configured_smtp():
+    cfg = EmailConfig(
+        api_key=None,
+        from_email='noreply@example.com',
+        service_provider='smtp',
+        smtp_host='smtp.example.com',
+    )
+    assert is_email_configured(cfg) is True
+
+
+@patch('backend.email_service.requests.post')
+def test_send_password_reset_email_sendgrid_success(mock_post):
+    mock_post.return_value = MagicMock(status_code=202, text='')
+    cfg = EmailConfig(
+        api_key='sg-test',
+        from_email='noreply@bibliodrift.com',
+        service_provider='sendgrid',
+    )
+    result = send_password_reset_email(
+        'user@example.com',
+        'http://127.0.0.1:5500/pages/auth.html?token=abc',
+        cfg,
+    )
+    assert result.ok is True
+    mock_post.assert_called_once()
+    assert mock_post.call_args.kwargs['json']['personalizations'][0]['to'][0]['email'] == 'user@example.com'
+
+
+@patch('backend.email_service.requests.post')
+def test_send_password_reset_email_sendgrid_failure(mock_post):
+    mock_post.return_value = MagicMock(status_code=403, text='Forbidden')
+    cfg = EmailConfig(
+        api_key='sg-test',
+        from_email='noreply@bibliodrift.com',
+        service_provider='sendgrid',
+    )
+    result = send_password_reset_email(
+        'user@example.com',
+        'http://127.0.0.1:5500/pages/auth.html?token=abc',
+        cfg,
+    )
+    assert result.ok is False
+
+
+@patch('backend.email_service.smtplib.SMTP')
+def test_send_password_reset_email_smtp_success(mock_smtp_cls):
+    mock_smtp = MagicMock()
+    mock_smtp_cls.return_value.__enter__.return_value = mock_smtp
+    cfg = EmailConfig(
+        api_key=None,
+        from_email='noreply@bibliodrift.com',
+        service_provider='smtp',
+        smtp_host='localhost',
+        smtp_port=1025,
+        smtp_use_tls=False,
+    )
+    result = send_password_reset_email(
+        'user@example.com',
+        'http://127.0.0.1:5500/pages/auth.html?token=abc',
+        cfg,
+    )
+    assert result.ok is True
+    mock_smtp.send_message.assert_called_once()

--- a/tests/test_forgot_password_email.py
+++ b/tests/test_forgot_password_email.py
@@ -1,0 +1,53 @@
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from backend.email_service import EmailSendResult
+
+
+@patch('backend.app.send_password_reset_email')
+@patch('backend.app.is_email_configured', return_value=True)
+def test_forgot_password_sends_email_when_configured(
+    _mock_configured,
+    mock_send,
+    client,
+    test_user,
+):
+    mock_send.return_value = EmailSendResult(ok=True)
+
+    res = client.post(
+        '/api/v1/auth/forgot-password',
+        json={'email': test_user.email},
+    )
+
+    assert res.status_code == 200
+    body = res.get_json()
+    assert body.get('reset_url') is None
+    mock_send.assert_called_once()
+    assert mock_send.call_args[0][0] == test_user.email
+
+
+@patch('backend.app.send_password_reset_email')
+@patch('backend.app.is_email_configured', return_value=False)
+def test_forgot_password_dev_reset_url_when_email_disabled(
+    _mock_configured,
+    mock_send,
+    client,
+    test_user,
+    monkeypatch,
+):
+    monkeypatch.setenv('APP_ENV', 'development')
+    res = client.post(
+        '/api/v1/auth/forgot-password',
+        json={'email': test_user.email},
+    )
+
+    assert res.status_code == 200
+    body = res.get_json()
+    assert 'reset_url' in body
+    assert 'token=' in body['reset_url']
+    mock_send.assert_not_called()


### PR DESCRIPTION
## Description

Adds real email delivery for the existing password reset flow (forgot/reset API + auth UI).

- New `backend/email_service.py` reads `EmailConfig` and sends reset links via **Sendgrid** (HTTP API) or **SMTP** (`smtplib`).
- `POST /api/v1/auth/forgot-password` sends email when `EMAIL_*` is configured; **`reset_url` is only returned in development** when email is not configured (same security model as before for prod).
- Extended `EmailConfig` and `config/.env.example` with SMTP settings and `FRONTEND_ORIGIN` for links in emails.
- Frontend: “missing reset link” helper on auth page only on localhost (avoids confusing production users after a real email send).
- Tests: `test_email_service.py`, `test_forgot_password_email.py`; fixed `conftest.py` to use the same `db` instance as `backend.app`.

## Related Issue

Fixes #762

## Type of Change

- [ ] Bug Fix  
- [x] Feature  
- [ ] Enhancement  
- [ ] Documentation  

## Testing

```bash
export GOOGLE_BOOKS_API_KEY=fake-key-for-testing JWT_SECRET_KEY=test-jwt-secret-key DATABASE_URL=sqlite:///:memory:
python3 -m pytest tests/test_email_service.py tests/test_forgot_password_email.py tests/test_password_reset.py -v