### PR TITLE
 fix: add localhost:8080 CORS origins and dev server setup to resolve Failed to fetch on signup (#494)

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,10 +208,21 @@ This ensures discovery stays organic, scalable, and aligned with BiblioDrift’s
    bash
    git clone https://github.com/devanshi14malhotra/bibliodrift.git
    
-2. Open index.html in your browser.
-   - That's it! No build steps required for the vanilla frontend.
+2. Serve the frontend using a local HTTP server (do NOT open HTML files directly in the browser):
+```bash
+   cd frontend
+   python -m http.server 8080
+```
+3. Start the backend:
+```bash
+   cd backend
+   python app.py
+```
+4. Open `http://localhost:8080/pages/auth.html` in your browser.
 
-### Backend
+> ⚠️ **Important:** Opening HTML files directly via `file:///` URLs will cause a CORS error (`TypeError: Failed to fetch`) because the browser blocks all fetch requests from a `null` origin. Always use a local server.
+
+### Backend 
 The Flask backend powers authentication, library sync, AI blurbs, chat, mood analysis, and other API flows.
 
 ## 🚢 Deployment Notes

--- a/backend/app.py
+++ b/backend/app.py
@@ -122,7 +122,7 @@ jwt = JWTManager(app)
 # =====================================================================
 # ALLOWED_ORIGINS=http://127.0.0.1:5500,http://localhost:5500,http://127.0.0.1:5000,http://localhost:5000
 # For development, we'll allow all to be safe, then restrict in prod
-CORS(app, supports_credentials=True, origins=["http://127.0.0.1:5500", "http://localhost:5500", "http://127.0.0.1:5000", "http://localhost:5000"])
+CORS(app, supports_credentials=True, origins=["http://127.0.0.1:5500", "http://localhost:5500", "http://127.0.0.1:5000", "http://localhost:5000", "http://127.0.0.1:8080", "http://localhost:8080"])
 
 # Initialize cache service
 cache_service.init_app(app)


### PR DESCRIPTION
## Description
Fixes the `TypeError: Failed to fetch` error on the Create Account page by:
1. Adding `http://localhost:8080` and `http://127.0.0.1:8080` to the CORS allowed origins in `backend/app.py`
2. Updating README to document that the frontend must be served via `python -m http.server 8080` instead of opening HTML files directly

## Related Issue
Fixes #494

## Type of Change
- [x] Bug Fix
- [x] Documentation

## Root Cause
Opening HTML files directly via `file:///` gives the browser a `null` origin, which is blocked by CORS. Serving via `localhost:8080` gives a proper origin that the backend now accepts.

## Testing
- Served frontend via `python -m http.server 8080`
- Opened `http://localhost:8080/pages/auth.html`
- Created account successfully with no fetch errors

## Checklist
- [x] Code follows guidelines
- [x] Tested properly
- [x] Docs updated