### PR TITLE
[GSSoC'26] Fix N+1 query issue in public collections endpoint

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2387,21 +2387,28 @@ def get_public_collections():
     try:
         limit = request.args.get('limit', 20, type=int)
         offset = request.args.get('offset', 0, type=int)
-        
+
         collections = Collection.query.filter_by(is_public=True).order_by(
             Collection.created_at.desc()
         ).offset(offset).limit(limit).all()
-        
+
         total = Collection.query.filter_by(is_public=True).count()
-        
+
         result = []
         for c in collections:
             collection_data = c.to_dict()
-            user = User.query.get(c.user_id)
-            collection_data['owner_username'] = user.username if user else "Unknown"
+            collection_data['owner_username'] = (
+                c.user.username if c.user else "Unknown"
+            )
             result.append(collection_data)
-        
-        return jsonify({"collections": result, "total": total, "limit": limit, "offset": offset}), 200
+
+        return jsonify({
+            "collections": result,
+            "total": total,
+            "limit": limit,
+            "offset": offset
+        }), 200
+
     except Exception as e:
         return jsonify({"error": str(e)}), 500
 


### PR DESCRIPTION
## Description

This PR fixes the N+1 query issue in the public collections endpoint.

Previously, the endpoint executed an additional `User.query.get(c.user_id)` query for every collection while constructing the response. Since the `Collection` model already has an eagerly loaded `user` relationship (`lazy='joined'`), these extra database queries were redundant and could negatively impact performance when returning multiple collections.

### Changes Made
- Removed redundant `User.query.get(c.user_id)` calls inside the collections loop.
- Utilized the existing `Collection.user` relationship to fetch the collection owner's username.
- Preserved the existing API response structure and functionality.

This optimization reduces unnecessary database queries and improves the efficiency of the public collections endpoint.

## Related Issue

Fixes #1053

## Type of Change

- [x] Bug Fix
- [ ] Feature
- [ ] Enhancement
- [ ] Documentation

## Testing

- Verified the code changes for correctness.
- Confirmed that `owner_username` is still included in the API response.
- Ensured the endpoint now uses the existing relationship instead of performing per-collection user lookups.

## Screenshots

N/A (backend performance optimization)

## Checklist

- [x] Code follows guidelines
- [x] Tested properly
- [ ] Docs updated
- [x] PR title includes the relevant event tag or a general contribution label