### PR TITLE
Enhancement: Add Spotify playlists link to Ambient Sanctuary #1112

### DIFF
--- a/frontend/pages/app.html
+++ b/frontend/pages/app.html
@@ -532,6 +532,14 @@
           <span class="slider"></span>
         </label>
       </div>
+      <div class="ambient-option" style="margin-bottom: 15px; padding-bottom: 15px; border-bottom: 1px solid rgba(147, 112, 98, 0.2);">
+        <a href="spotify-playlists.html" style="color: var(--text-main) !important; text-decoration: none; display: flex; justify-content: space-between; align-items: center; width: 100%;">
+          <span><i class="fa-brands fa-spotify" style="color: #1DB954;"></i> Spotify Playlists</span>
+          <i class="fa-solid fa-arrow-up-right-from-square" style="font-size: 0.85rem; opacity: 0.7;"></i>
+        </a>
+      </div>
+
+      <div class="volume-control">
       <div class="volume-control">
         <label for="ambientVolume" style="color: var(--text-main) !important;"><i class="fa-solid fa-volume-high"></i>
           Volume</label>
@@ -539,6 +547,7 @@
           <div class="range-track" aria-hidden="true"></div>
           <div class="range-fill" aria-hidden="true"></div>
           <input type="range" id="ambientVolume" min="0" max="1" step="0.1" value="0.5" style="width: 100%;">
+          
         </div>
       </div>
     </div>

--- a/frontend/pages/library.html
+++ b/frontend/pages/library.html
@@ -657,6 +657,14 @@
                     <span class="slider"></span>
                 </label>
             </div>
+            <div class="ambient-option" style="margin-bottom: 15px; padding-bottom: 15px; border-bottom: 1px solid rgba(147, 112, 98, 0.2);">
+        <a href="spotify-playlists.html" style="color: var(--text-main) !important; text-decoration: none; display: flex; justify-content: space-between; align-items: center; width: 100%;">
+          <span><i class="fa-brands fa-spotify" style="color: #1DB954;"></i> Spotify Playlists</span>
+          <i class="fa-solid fa-arrow-up-right-from-square" style="font-size: 0.85rem; opacity: 0.7;"></i>
+        </a>
+      </div>
+
+      <div class="volume-control">
             <div class="volume-control">
                 <label for="ambientVolume" style="color: var(--text-main) !important;"><i
                         class="fa-solid fa-volume-high"></i> Volume</label>
@@ -664,6 +672,7 @@
                     <div class="range-track" aria-hidden="true"></div>
                     <div class="range-fill" aria-hidden="true"></div>
                     <input type="range" id="ambientVolume" min="0" max="1" step="0.1" value="0.5" style="width: 100%;">
+                    
                 </div>
             </div>
         </div>


### PR DESCRIPTION
#1112 

## Description
This PR integrates the existing `spotify-playlists.html` page into the main UI. Previously, the Spotify playlists page was orphaned and inaccessible. 

I have added a direct link to the **Ambient Sanctuary** panel in both `app.html` and `library.html`. The link is placed cleanly above the volume control to ensure it doesn't overlap or break the existing layout.

## Changes Made
- Added a `<a href="spotify-playlists.html">` link inside the Ambient Sanctuary widget.
- Positioned it between the "Stormy Rain" toggle and the "Volume Control" slider.
- Used the official Spotify brand color (`#1DB954`) for the icon to make it stand out.
- Adjusted padding and borders to keep the widget UI clean and prevent overlapping.

## Steps to Verify
1. Pull this branch and run locally.
2. Open `app.html` or `library.html`.
3. Click the leaf 🍃 icon at the bottom right to open the Ambient Sanctuary.
4. Verify that the "Spotify Playlists" link is visible above the volume slider.
5. Click the link and ensure it redirects to the correct page.
<img width="1917" height="922" alt="Screenshot 2026-05-28 234141" src="https://github.com/user-attachments/assets/8fd2a609-1dfb-4c78-b988-b64b8ec791b3" />
<img width="1878" height="903" alt="Screenshot 2026-05-28 234201" src="https://github.com/user-attachments/assets/9ff05a90-c558-497f-b8f4-75adc8c8b70f" />

@devanshi14malhotra pls review.
