### PR TITLE
[GSSoC'26] fix: resolve community stories modal popup dark mode issue (deprecated/closed)

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -76,7 +76,7 @@
     --input-bg: rgba(0, 0, 0, 0.2);
     --input-border: rgba(255, 255, 255, 0.1);
     --book-bg: #2c2420;
-    --paper-color: #e0d5cb;
+    --paper-color: var(--bg-color);
     /* Overrides */
     --shadow-hover: 0 15px 45px rgba(0, 0, 0, 0.5);
     --nav-active-color: #fff2df;


### PR DESCRIPTION
# Pull Request

## Description
This PR solves the issue of the modal popup in the Community Stories section not rendering properly when dark mode was enabled. 
The issue was caused due to the modal's background using a hardcoded hex colour assigned to `--paper-color` within `[data-theme="night"]`. I updated this to use the dynamic CSS variable `var(--bg-color)` in `/css/style.css`, ensuring the modal background now correctly adapts to the application's dark theme mode while preserving the original styling in light theme mode.

## Related Issue
Fixes # (deprecated)

## Type of Change
- [x] Bug Fix  
- [ ] Feature  
- [ ] Enhancement  
- [ ] Documentation  

## Testing
1. Ran the development server locally (`npm run dev`).
2. Navigated to `/pages/community-stories.html`.
3. Toggled the theme to Dark Mode using UI controls.
4. Triggered the modal popup and verified that all the elements displayed correctly without styling conflicts.

## Screenshots
<img width="1297" height="675" alt="image" src="https://github.com/user-attachments/assets/458348b1-e8ab-43ea-a34d-60c5e3900475" />
<img width="1365" height="628" alt="image" src="https://github.com/user-attachments/assets/41c3f6f5-27b0-41c7-9fb9-a6daddb6abdf" />

## Checklist
- [x] Code follows guidelines  
- [x] Tested properly  
- [ ] Docs updated  
- [x] PR title includes the relevant event tag or a general contribution label