### PR TITLE
fix: resolve contributors page layout alignment in dark mode

### DIFF
--- a/frontend/css/contributing.css
+++ b/frontend/css/contributing.css
@@ -2,9 +2,9 @@
 
 :root {
   --landing-bg: var(--bg-color);
-  --landing-surface: rgba(255,250,243,0.72);
-  --landing-surface-strong: rgba(255,255,255,0.86);
-  --landing-border: rgba(93,64,55,0.12);
+  --landing-surface: rgba(255, 250, 243, 0.72);
+  --landing-surface-strong: rgba(255, 255, 255, 0.86);
+  --landing-border: rgba(93, 64, 55, 0.12);
   --landing-shadow: var(--shadow-soft);
   --landing-gold: var(--accent-gold);
   --landing-wood: var(--wood-dark);
@@ -89,7 +89,7 @@ body {
 .landing-nav a.active {
   color: var(--landing-wood);
   font-weight: 600;
-  box-shadow: inset 0 -2px 0 rgba(212,175,55,0.08);
+  box-shadow: inset 0 -2px 0 rgba(212, 175, 55, 0.08);
 }
 
 .toc {
@@ -105,14 +105,14 @@ body {
   color: var(--landing-muted);
   padding: 0.45rem 0.75rem;
   border-radius: 999px;
-  background: rgba(255,255,255,0.7);
-  border: 1px solid rgba(93,64,55,0.06);
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(93, 64, 55, 0.06);
   transition: transform 0.15s ease, color 0.15s ease;
 }
 
-.toc a:hover { 
-  transform: translateY(-2px); 
-  color: var(--landing-ink); 
+.toc a:hover {
+  transform: translateY(-2px);
+  color: var(--landing-ink);
 }
 
 #backToTop {
@@ -120,10 +120,10 @@ body {
   right: 20px;
   bottom: 26px;
   background: var(--landing-surface-strong);
-  border: 1px solid rgba(93,64,55,0.08);
+  border: 1px solid rgba(93, 64, 55, 0.08);
   padding: 0.6rem 0.7rem;
   border-radius: 999px;
-  box-shadow: 0 10px 24px rgba(44,36,32,0.06);
+  box-shadow: 0 10px 24px rgba(44, 36, 32, 0.06);
   display: none;
   cursor: pointer;
   z-index: 120;
@@ -250,7 +250,7 @@ body {
 .guide-hero-aside {
   border-radius: 28px;
   border: 1px solid rgba(93, 64, 55, 0.08);
-  background: linear-gradient(180deg, rgba(255,255,255,0.94), rgba(255,250,243,0.88));
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(255, 250, 243, 0.88));
   box-shadow: 0 22px 44px rgba(44, 36, 32, 0.08);
 }
 
@@ -314,7 +314,7 @@ body {
   gap: 0.25rem;
   padding: 0.95rem 1rem;
   border-radius: 20px;
-  background: rgba(255,255,255,0.72);
+  background: rgba(255, 255, 255, 0.72);
   border: 1px solid rgba(93, 64, 55, 0.08);
 }
 
@@ -342,7 +342,7 @@ body {
   margin-top: 1rem;
   padding: 1.35rem;
   border-radius: 28px;
-  background: linear-gradient(180deg, rgba(255,255,255,0.97), rgba(255,250,243,0.91));
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.97), rgba(255, 250, 243, 0.91));
   border: 1px solid rgba(93, 64, 55, 0.08);
   box-shadow: 0 18px 34px rgba(44, 36, 32, 0.06);
 }
@@ -369,9 +369,9 @@ body {
 .guide-card {
   padding: 1.05rem;
   border-radius: 20px;
-  background: rgba(255,255,255,0.72);
+  background: rgba(255, 255, 255, 0.72);
   border: 1px solid rgba(93, 64, 55, 0.08);
-  box-shadow: inset 0 1px 0 rgba(255,255,255,0.6);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
 }
 
 .guide-card h3 {
@@ -389,7 +389,7 @@ body {
   height: 0.3rem;
   border-radius: 999px;
   margin-bottom: 0.9rem;
-  background: linear-gradient(90deg, rgba(212,175,55,0.7), rgba(127,150,160,0.4));
+  background: linear-gradient(90deg, rgba(212, 175, 55, 0.7), rgba(127, 150, 160, 0.4));
 }
 
 .guide-card ul,
@@ -405,7 +405,7 @@ body {
   gap: 0.45rem;
   padding: 0.45rem 0.8rem;
   border-radius: 999px;
-  background: rgba(255,255,255,0.76);
+  background: rgba(255, 255, 255, 0.76);
   border: 1px solid rgba(93, 64, 55, 0.08);
   color: var(--landing-muted);
   font-size: 0.92rem;
@@ -429,7 +429,7 @@ body {
   align-items: flex-start;
   padding: 0.9rem 1rem;
   border-radius: 18px;
-  background: rgba(255,255,255,0.72);
+  background: rgba(255, 255, 255, 0.72);
   border: 1px solid rgba(93, 64, 55, 0.08);
 }
 
@@ -458,7 +458,7 @@ body {
   border-radius: 20px;
   text-decoration: none;
   color: inherit;
-  background: rgba(255,255,255,0.78);
+  background: rgba(255, 255, 255, 0.78);
   border: 1px solid rgba(93, 64, 55, 0.08);
   box-shadow: 0 12px 24px rgba(44, 36, 32, 0.05);
   transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
@@ -556,8 +556,8 @@ body {
   --landing-bg: #111111;
   --landing-surface: #1b1b1b;
   --landing-surface-strong: #222222;
-  --landing-border: rgba(255,255,255,0.08);
-  --landing-shadow: 0 10px 30px rgba(0,0,0,0.5);
+  --landing-border: rgba(255, 255, 255, 0.08);
+  --landing-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
   --landing-gold: #d4af37;
   --landing-wood: #f5f5f5;
   --landing-ink: #ffffff;
@@ -568,8 +568,8 @@ body {
 
 [data-theme="night"] body {
   background:
-    radial-gradient(circle at top left, rgba(212,175,55,0.08), transparent 24%),
-    radial-gradient(circle at top right, rgba(127,150,160,0.06), transparent 18%),
+    radial-gradient(circle at top left, rgba(212, 175, 55, 0.08), transparent 24%),
+    radial-gradient(circle at top right, rgba(127, 150, 160, 0.06), transparent 18%),
     #111111;
   color: #ffffff;
 }
@@ -577,8 +577,8 @@ body {
 /* HEADER */
 
 [data-theme="night"] .landing-header {
-  background: rgba(20,20,20,0.9);
-  border: 1px solid rgba(255,255,255,0.06);
+  background: rgba(20, 20, 20, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.06);
 }
 
 /* HERO CARDS */
@@ -591,7 +591,7 @@ body {
 [data-theme="night"] .guide-hero-stat,
 [data-theme="night"] .page-link-card {
   background: #1c1c1c !important;
-  border: 1px solid rgba(255,255,255,0.08);
+  border: 1px solid rgba(255, 255, 255, 0.08);
   box-shadow: none;
 }
 
@@ -624,7 +624,7 @@ body {
 [data-theme="night"] .landing-icon-btn {
   background: #222222;
   color: white;
-  border: 1px solid rgba(255,255,255,0.08);
+  border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 /* NAVBAR LINKS */
@@ -634,7 +634,7 @@ body {
 }
 
 [data-theme="night"] .landing-nav a:hover {
-  background: rgba(255,255,255,0.08);
+  background: rgba(255, 255, 255, 0.08);
 }
 
 /* TOC LINKS */
@@ -642,13 +642,13 @@ body {
 [data-theme="night"] .toc a {
   background: #222222;
   color: white;
-  border: 1px solid rgba(255,255,255,0.08);
+  border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 /* PAGE LINK ICON */
 
 [data-theme="night"] .page-link-card i {
-  background: rgba(255,255,255,0.08);
+  background: rgba(255, 255, 255, 0.08);
   color: #ffffff;
 }
 

--- a/frontend/css/contributors.css
+++ b/frontend/css/contributors.css
@@ -203,3 +203,64 @@ header {
     max-width: 100%;
   }
 }
+
+
+[data-theme="night"] body {
+  background:
+    radial-gradient(circle at top left, rgba(212, 175, 55, 0.08), transparent 24%),
+    radial-gradient(circle at top right, rgba(127, 150, 160, 0.06), transparent 18%),
+    #111111 !important;
+  color: #ffffff !important;
+}
+
+[data-theme="night"] header {
+  background: rgba(20, 20, 20, 0.9) !important;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06) !important;
+}
+
+[data-theme="night"] .contributor-card {
+  background: #1c1c1c !important;
+  border-color: rgba(255, 255, 255, 0.08) !important;
+  box-shadow: none !important;
+}
+
+[data-theme="night"] .contributor-card:hover,
+[data-theme="night"] .contributor-card:focus-visible {
+  background: #252525 !important;
+  border-color: rgba(212, 175, 55, 0.3) !important;
+  box-shadow: none !important;
+}
+
+[data-theme="night"] .contributor-avatar {
+  border-color: rgba(255, 255, 255, 0.1) !important;
+  background: #111111 !important;
+}
+
+[data-theme="night"] .contributors-note {
+  background: #ffffff !important;
+  color: #111111 !important;
+  border-color: rgba(0, 0, 0, 0.1) !important;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15) !important;
+}
+
+[data-theme="night"] .contributors-note i {
+  color: #111111 !important;
+}
+
+[data-theme="night"] .nav-links .tooltip a:hover {
+  background: rgba(255, 255, 255, 0.08) !important;
+}
+
+/* Heading & Text Color Alignments */
+[data-theme="night"] h1,
+[data-theme="night"] p,
+[data-theme="night"] a,
+[data-theme="night"] span,
+[data-theme="night"] .logo {
+  color: #ffffff !important;
+}
+
+[data-theme="night"] .meta,
+[data-theme="night"] .contributor-count {
+  color: #d1d5db !important;
+}


### PR DESCRIPTION
Pull Request
This PR is a contribution for GSSoC'26.

Description
Resolved specific styling and layout alignment issues on the Contributors page that were breaking when the interface was toggled into Dark Mode.

Related Issue
Fixes #1124

Type of Change
- [x] Bug Fix  
- [ ] Feature  
- [ ] Enhancement  
- [ ] Documentation  

Testing
Local UI Inspection: Ran the application locally via Live Server (`127.0.0.1:5501`) to track styling rendering changes in real-time.
Theme Switching Validation: Toggled the application's global dark/light mode button repeatedly to ensure container backgrounds, card borders, and text contrast on both the Contributors and Contributing pages dynamically update without breaking layout flow.
Layout Alignment Verification: Confirmed that structural element shifts and card alignments are properly contained and readable when dark mode selectors are active.

Screenshots
<img width="1365" height="677" alt="image" src="https://github.com/user-attachments/assets/e2293d31-0afe-40bc-84df-c9249b8b5d26" />

Checklist
- [x] Code follows guidelines  
- [x] Tested properly  
- [ ] Docs updated  
- [x] PR title includes the relevant event tag or a general contribution label