### PR TITLE
[GSSoC'26] fix: resolve community stories modal popup background issue in dark mode

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -7935,6 +7935,10 @@ body.night-mode .tooltip-author {
   transform: translateY(-2px);
 }
 
+/* Story Modal (Dark Mode) Popup Targeted Fix */
+[data-theme='night'] .story-read-modal {
+    background: var(--bg-color);
+}
 
 /* ============================================================ */
 /* IN-APP BOOK PREVIEW MODAL (Google Books Embedded Viewer)    */


### PR DESCRIPTION
# Pull Request

## Description
This PR solves the issue of the modal popup in the Community Stories section not rendering properly when dark mode was enabled.
The issue was caused due to the modal's background using a hardcoded hex colour assigned to `--paper-color` within `[data-theme="night"]`. I updated this to use the dynamic CSS variable `background: var(--bg-color)` in `/css/style.css`, specifically targeting `[data-theme="night"]` for `.story-read-modal`, ensuring the modal background now correctly adapts to the application's dark theme mode while preserving the original styling in light theme mode, and that global styling isn't affected.

## Related Issue
Fixes #1025 

## Type of Change
- [x] Bug Fix  
- [ ] Feature  
- [ ] Enhancement  
- [ ] Documentation  

## Testing
1. Ran the development server locally `(npm run dev)`. 
2. Navigated to `/pages/community-stories.html`. 
3. Toggled the theme to Dark Mode using UI controls. 
4. Triggered the modal popup and verified that all the elements displayed correctly without styling conflicts.
5. Checked across application to ensure global variables weren't affected and that no styling conflicts occurred.

## Screenshots
[
<img width="1297" height="644" alt="Screenshot 2026-05-29 204511" src="https://github.com/user-attachments/assets/b59c0dfd-d790-4338-996d-6d86d6e00290" />
<img width="1294" height="672" alt="Screenshot 2026-05-29 204527" src="https://github.com/user-attachments/assets/59ac2ea7-846d-4d32-9b0f-fa6ecfdc84c2" />
](url)

## Checklist
- [x] Code follows guidelines  
- [x] Tested properly  
- [ ] Docs updated  
- [x] PR title includes the relevant event tag or a general contribution label