### PR TITLE
fix: deploy contributors fallback JSON with Netlify build

### DIFF
--- a/build_netlify.py
+++ b/build_netlify.py
@@ -81,21 +81,18 @@ def write_clean_route_redirects() -> None:
         "/community-stories /community-stories.html 200",
         "/nearby-bookstores /nearby-bookstores.html 200",
     ]
-    (DIST / "_redirects").write_text("
-".join(redirects) + "
-", encoding="utf-8")
+    (DIST / "_redirects").write_text("\n".join(redirects) + "\n", encoding="utf-8")
 
 
 def inject_api_base_override() -> None:
-    """Optional Netlify build env MOOD_API_BASE -> runtime override in dist config.js."""
+    """Optional Netlify build env MOOD_API_BASE → runtime override in dist config.js."""
     api_base = os.getenv("MOOD_API_BASE", "").strip()
     if not api_base:
         return
     config_path = DIST / "js" / "config.js"
     if not config_path.exists():
         return
-    snippet = f'window.__MOOD_API_BASE_OVERRIDE__ = {api_base!r};
-'
+    snippet = f'window.__MOOD_API_BASE_OVERRIDE__ = {api_base!r};\n'
     content = config_path.read_text(encoding="utf-8")
     config_path.write_text(snippet + content, encoding="utf-8")
 

--- a/build_netlify.py
+++ b/build_netlify.py
@@ -81,25 +81,28 @@ def write_clean_route_redirects() -> None:
         "/community-stories /community-stories.html 200",
         "/nearby-bookstores /nearby-bookstores.html 200",
     ]
-    (DIST / "_redirects").write_text("\n".join(redirects) + "\n", encoding="utf-8")
+    (DIST / "_redirects").write_text("
+".join(redirects) + "
+", encoding="utf-8")
 
 
 def inject_api_base_override() -> None:
-    """Optional Netlify build env MOOD_API_BASE → runtime override in dist config.js."""
+    """Optional Netlify build env MOOD_API_BASE -> runtime override in dist config.js."""
     api_base = os.getenv("MOOD_API_BASE", "").strip()
     if not api_base:
         return
     config_path = DIST / "js" / "config.js"
     if not config_path.exists():
         return
-    snippet = f'window.__MOOD_API_BASE_OVERRIDE__ = {api_base!r};\n'
+    snippet = f'window.__MOOD_API_BASE_OVERRIDE__ = {api_base!r};
+'
     content = config_path.read_text(encoding="utf-8")
     config_path.write_text(snippet + content, encoding="utf-8")
 
 
 def main() -> None:
     reset_dist()
-    for folder in ("css", "js", "assets", "script"):
+    for folder in ("css", "js", "assets", "script", "data"):
         copy_tree(folder)
         
     manifest_src = SOURCE / "manifest.json"


### PR DESCRIPTION
## Summary
- copy `frontend/data` into `dist/data` during the Netlify build
- restore the deployed `/data/contributors.json` fallback path used by the landing contributors loader
- keep the fix scoped to the build script only

Closes #1008

## Testing
- verified the issue�s build path and fallback loader references in `build_netlify.py` and `frontend/js/landing-contributors.js`
- verified the PR diff is limited to the single build-copy line needed for `dist/data`
- local full build/test run was not performed here because this environment is out of space for a clean repo checkout

## GSSoC
Please add the required `gssoc:approved` label if this PR is valid for GSSoC 2026.
