### PR TITLE
fix: resolve critical responsive design failure in global header navigation on mobile viewports

### DIFF
--- a/frontend/css/style-responsive.css
+++ b/frontend/css/style-responsive.css
@@ -154,8 +154,11 @@ input {
 
     /* Header Stack Layout */
     header {
-        flex-direction: column;
-        padding: 0.5rem;
+        flex-direction: row;
+        flex-wrap: wrap;
+        justify-content: space-between;
+        align-items: center;
+        padding: 0.5rem 1rem;
         gap: 0.5rem;
         height: auto;
         position: sticky;
@@ -163,10 +166,30 @@ input {
         z-index: 100;
     }
 
+    .mobile-menu-toggle {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 44px;
+        min-width: 44px;
+        background: transparent;
+        border: 1px solid var(--control-border);
+        border-radius: 8px;
+        color: var(--text-main);
+        font-size: 1.5rem;
+        cursor: pointer;
+    }
+
     .header-controls {
+        display: none;
         flex-direction: column;
         width: 100%;
-        gap: 0.5rem;
+        gap: 1rem;
+        margin-top: 1rem;
+    }
+
+    .header-controls.nav-active {
+        display: flex;
     }
 
     .search-bar {
@@ -212,6 +235,7 @@ input {
         gap: 1rem;
         padding-bottom: 1rem;
         overflow-x: auto;
+    }
 
         .hero h1 {
             font-size: var(--type-display-size);

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -249,6 +249,10 @@ h3 {
 }
 
 /* --- Layout --- */
+.mobile-menu-toggle {
+    display: none;
+}
+
 header {
     padding: 1.5rem 4rem;
     display: flex;

--- a/frontend/js/footer.js
+++ b/frontend/js/footer.js
@@ -73,3 +73,5 @@ const createFooter = () => {
 };
 
 createFooter();
+
+// Mobile Menu Toggle Event Listener has been moved to pwa.js for global coverage

--- a/frontend/js/pwa.js
+++ b/frontend/js/pwa.js
@@ -271,3 +271,29 @@
     if (!navigator.onLine) _showOfflineIndicator();
 
 })();
+
+// Global Mobile Menu Toggle Logic
+document.addEventListener('DOMContentLoaded', () => {
+    const toggleBtns = document.querySelectorAll('.mobile-menu-toggle');
+    toggleBtns.forEach(toggleBtn => {
+        const header = toggleBtn.closest('header') || toggleBtn.closest('.landing-header');
+        if (header) {
+            const headerControls = header.querySelector('.header-controls');
+            toggleBtn.addEventListener('click', () => {
+                if (headerControls) {
+                    headerControls.classList.toggle('nav-active');
+                } else {
+                    header.classList.toggle('nav-active');
+                }
+                const icon = toggleBtn.querySelector('i');
+                if (icon) {
+                    if (icon.classList.contains('fa-bars')) {
+                        icon.classList.replace('fa-bars', 'fa-times');
+                    } else {
+                        icon.classList.replace('fa-times', 'fa-bars');
+                    }
+                }
+            });
+        }
+    });
+});

--- a/frontend/pages/404.html
+++ b/frontend/pages/404.html
@@ -25,6 +25,9 @@
     <a href="app.html" class="logo">
       <img style="height: 40px" src="../assets/images/biblioDrift_favicon.png" alt="BiblioDrift Logo"> BiblioDrift
     </a>
+    <button class="mobile-menu-toggle" id="mobileMenuToggle" aria-label="Toggle navigation">
+      <i class="fa-solid fa-bars"></i>
+    </button>
     <div class="header-controls">
       <div class="search-bar">
         <input type="text" id="searchInput" class="search-input" placeholder="Search for a feeling...">

--- a/frontend/pages/app.html
+++ b/frontend/pages/app.html
@@ -69,9 +69,10 @@
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
   <title>BiblioDrift | Find yourself in the pages</title>
-  <link rel="stylesheet" href="../css/style.css" />
-  <link rel="stylesheet" href="../css/keyboard-shortcuts.css" />
-  <link rel="stylesheet" href="../css/pwa.css">
+  <link rel="stylesheet" href="../css/style.css?v=2" />
+  <link rel="stylesheet" href="../css/style-responsive.css?v=2" />
+  <link rel="stylesheet" href="../css/keyboard-shortcuts.css?v=2" />
+  <link rel="stylesheet" href="../css/pwa.css?v=2">
   <link rel="stylesheet" href="../css/app-page.css" />
   <link rel="manifest" href="../manifest.json">
   <!-- Fonts -->
@@ -102,6 +103,9 @@
     <a href="app.html" class="logo">
       <img style="height: 40px" src="../assets/images/biblioDrift_favicon.png" alt="BiblioDrift Logo"> BiblioDrift
     </a>
+    <button class="mobile-menu-toggle" id="mobileMenuToggle" aria-label="Toggle navigation">
+      <i class="fa-solid fa-bars"></i>
+    </button>
     <div class="header-controls">
       <div class="search-bar">
         <input type="text" id="searchInput" class="search-input" placeholder="Search for a feeling...">
@@ -516,7 +520,7 @@
 
   <script src="../js/ambient.js"></script>
   <script src="../js/security.js"></script>
-  <script src="../js/pwa.js"></script>
+  <script src="../js/pwa.js?v=2"></script>
   <!-- AI Chatbot Widget -->
   <div id="ai-chatbot-widget" class="chatbot-widget">
     <button id="chatbot-toggle-btn" class="chatbot-toggle-btn" title="Chat with Elara">

--- a/frontend/pages/auth.html
+++ b/frontend/pages/auth.html
@@ -561,6 +561,9 @@
         <a href="app.html" class="logo">
             <img style="height: 40px" src="../assets/images/biblioDrift_favicon.png" alt="BiblioDrift Logo"> BiblioDrift
         </a>
+        <button class="mobile-menu-toggle" id="mobileMenuToggle" aria-label="Toggle navigation">
+          <i class="fa-solid fa-bars"></i>
+        </button>
         <div class="header-controls">
             <div class="search-bar">
                 <input type="text" id="searchInput" class="search-input" placeholder="Search for a feeling...">

--- a/frontend/pages/chat.html
+++ b/frontend/pages/chat.html
@@ -54,8 +54,9 @@
     <meta property="og:image" content="https://bibliodrift-dm.netlify.app/assets/images/og-banner.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
-    <link rel="stylesheet" href="../css/style.css">
-    <link rel="stylesheet" href="../css/pwa.css">
+    <link rel="stylesheet" href="../css/style.css?v=2">
+    <link rel="stylesheet" href="../css/style-responsive.css?v=2">
+    <link rel="stylesheet" href="../css/pwa.css?v=2">
     <!-- Unified Font Imports -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -308,6 +309,9 @@
     <a href="app.html" class="logo">
       <img style="height: 40px" src="../assets/images/biblioDrift_favicon.png" alt="BiblioDrift Logo"> BiblioDrift
     </a>
+    <button class="mobile-menu-toggle" id="mobileMenuToggle" aria-label="Toggle navigation">
+      <i class="fa-solid fa-bars"></i>
+    </button>
     <div class="header-controls">
       <div class="search-bar">
         <input type="text" id="searchInput" class="search-input" placeholder="Search for a feeling...">
@@ -544,7 +548,7 @@
     <script src="../js/app.js"></script>
     <script src="../js/footer.js"></script>
     <script src="../script/header-scroll.js"></script>
-    <script src="../js/pwa.js"></script>
+    <script src="../js/pwa.js?v=2"></script>
 </body>
 
 </html>

--- a/frontend/pages/community-stories.html
+++ b/frontend/pages/community-stories.html
@@ -11,7 +11,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="BiblioDrift Community Stories – Read and publish your own stories." />
   <title>Community Stories | BiblioDrift</title>
-  <link rel="stylesheet" href="../css/style.css" />
+  <link rel="stylesheet" href="../css/style.css?v=2" />
+  <link rel="stylesheet" href="../css/style-responsive.css?v=2" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,600;1,400&family=Georgia&display=swap" rel="stylesheet" />
@@ -429,6 +430,9 @@
     <a href="app.html" class="logo">
       <img style="height: 40px" src="../assets/images/biblioDrift_favicon.png" alt="BiblioDrift Logo"> BiblioDrift
     </a>
+    <button class="mobile-menu-toggle" id="mobileMenuToggle" aria-label="Toggle navigation">
+      <i class="fa-solid fa-bars"></i>
+    </button>
     <div class="header-controls">
       <nav class="nav-links">
         <div class="tooltip">

--- a/frontend/pages/contributors.html
+++ b/frontend/pages/contributors.html
@@ -12,7 +12,8 @@
   </script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Contributors | BiblioDrift</title>
-  <link rel="stylesheet" href="../css/style.css" />
+  <link rel="stylesheet" href="../css/style.css?v=2" />
+  <link rel="stylesheet" href="../css/style-responsive.css?v=2" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -26,6 +27,9 @@
     <a href="index.html" class="logo">
       <img style="height: 40px" src="../assets/images/biblioDrift_favicon.png" alt="BiblioDrift Logo"> BiblioDrift
     </a>
+    <button class="mobile-menu-toggle" id="mobileMenuToggle" aria-label="Toggle navigation">
+      <i class="fa-solid fa-bars"></i>
+    </button>
     <div class="header-controls">
       <nav class="nav-links">
         <div class="tooltip">

--- a/frontend/pages/index.html
+++ b/frontend/pages/index.html
@@ -47,9 +47,9 @@
             }
         })();
     </script>
-    <link rel="stylesheet" href="../css/style.css" />
-    <link rel="stylesheet" href="../css/style-responsive.css" />
-    <link rel="stylesheet" href="../css/keyboard-shortcuts.css" />
+    <link rel="stylesheet" href="../css/style.css?v=2" />
+    <link rel="stylesheet" href="../css/style-responsive.css?v=2" />
+    <link rel="stylesheet" href="../css/keyboard-shortcuts.css?v=2" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -57,7 +57,7 @@
         rel="stylesheet" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
     <link rel="icon" href="../assets/images/biblioDrift_favicon.png" type="image/png" />
-    <link rel="stylesheet" href="../css/landing.css" />
+    <link rel="stylesheet" href="../css/landing.css?v=2" />
     <style>
         :root {
             --landing-bg: #f9f7f2;
@@ -1916,6 +1916,98 @@
             .contributors-panel { padding: 0.85rem; border-radius: 22px; }
             .contributors-grid-view { grid-template-columns: 1fr; }
         }
+        @media (max-width: 768px) {
+            .landing-header {
+                flex-wrap: wrap;
+                justify-content: space-between;
+                padding: 0.8rem;
+                position: relative;
+            }
+
+            .landing-brand {
+                order: 1;
+            }
+            
+            .mobile-menu-toggle {
+                display: flex;
+                order: 2;
+                align-items: center;
+                justify-content: center;
+                min-height: 44px;
+                min-width: 44px;
+                background: transparent;
+                border: 1px solid rgba(212, 175, 55, 0.3);
+                border-radius: 8px;
+                color: var(--landing-ink);
+                font-size: 1.5rem;
+                cursor: pointer;
+                margin-left: auto;
+            }
+
+            .landing-nav, .landing-header-actions {
+                display: none;
+                width: 100%;
+                flex-direction: column;
+                align-items: center;
+                order: 3;
+                margin-top: 1rem;
+                gap: 1rem;
+            }
+
+            .landing-header.nav-active .landing-nav,
+            .landing-header.nav-active .landing-header-actions {
+                display: flex;
+            }
+
+            .landing-nav a {
+                padding: 0.8rem;
+                font-size: 1.1rem;
+                width: 100%;
+                text-align: center;
+                border-bottom: 1px solid rgba(0,0,0,0.05);
+            }
+            
+            .landing-header-actions {
+                border-top: 1px solid rgba(0,0,0,0.05);
+                padding-top: 1rem;
+            }
+            
+            .landing-hero,
+            .about-grid,
+            .feature-grid,
+            .community-grid,
+            .testimonial-grid,
+            .workflow-grid,
+            .footer-grid {
+                grid-template-columns: 1fr;
+                padding: 1rem;
+            }
+
+            .eyebrow-row {
+                justify-content: center;
+            }
+            
+            .hero-copy {
+                text-align: center;
+                align-items: center;
+            }
+            
+            .hero-copy h1 {
+                font-size: clamp(2.5rem, 8vw, 3.5rem);
+                max-width: 100%;
+            }
+
+            .landing-cta-group {
+                justify-content: center;
+                width: 100%;
+            }
+
+            .btn-primary.landing-cta-primary, 
+            .btn-ghost {
+                width: 100%;
+                justify-content: center;
+            }
+        }
     </style>
     <link rel="manifest" href="../manifest.json">
     <link rel="stylesheet" href="../css/pwa.css">
@@ -1932,6 +2024,9 @@
                 <img src="../assets/images/biblioDrift_favicon.png" alt="BiblioDrift logo" />
                 <span>BiblioDrift</span>
             </a>
+            <button class="mobile-menu-toggle" id="landingMenuToggle" aria-label="Toggle navigation">
+                <i class="fa-solid fa-bars"></i>
+            </button>
             <nav class="landing-nav" aria-label="Landing sections">
                 <a href="#about-project">About</a>
                 <a href="#key-features">Features</a>
@@ -2691,7 +2786,7 @@
     <script src="../js/theme-manager.js"></script>
     <script src="../js/landing-interactions.js"></script>
     <script src="../js/ambient.js"></script>
-    <script src="../js/pwa.js"></script>
+    <script src="../js/pwa.js?v=2"></script>
 </body>
 
 </html>

--- a/frontend/pages/library.html
+++ b/frontend/pages/library.html
@@ -60,6 +60,9 @@
     <a href="app.html" class="logo">
       <img style="height: 40px" src="../assets/images/biblioDrift_favicon.png" alt="BiblioDrift Logo"> BiblioDrift
     </a>
+    <button class="mobile-menu-toggle" id="mobileMenuToggle" aria-label="Toggle navigation">
+      <i class="fa-solid fa-bars"></i>
+    </button>
     <div class="header-controls">
       <div class="search-bar">
         <input type="text" id="searchInput" class="search-input" placeholder="Search for a feeling...">

--- a/frontend/pages/nearby-bookstores.html
+++ b/frontend/pages/nearby-bookstores.html
@@ -39,6 +39,9 @@
     <a href="index.html" class="logo">
       <img style="height: 40px" src="../assets/images/biblioDrift_favicon.png" alt="BiblioDrift Logo"> BiblioDrift
     </a>
+    <button class="mobile-menu-toggle" id="mobileMenuToggle" aria-label="Toggle navigation">
+      <i class="fa-solid fa-bars"></i>
+    </button>
     <div class="header-controls">
       <div class="search-bar">
         <input type="text" id="searchInput" class="search-input" placeholder="Search for a feeling...">

--- a/frontend/pages/privacy-policy.html
+++ b/frontend/pages/privacy-policy.html
@@ -363,6 +363,9 @@
     <a href="index.html" class="logo">
       <img style="height: 40px" src="../assets/images/biblioDrift_favicon.png" alt="BiblioDrift Logo"> BiblioDrift
     </a>
+    <button class="mobile-menu-toggle" id="mobileMenuToggle" aria-label="Toggle navigation">
+      <i class="fa-solid fa-bars"></i>
+    </button>
     <div class="header-controls">
       <div class="search-bar">
         <input type="text" id="searchInput" class="search-input" placeholder="Search for a feeling...">

--- a/frontend/pages/profile.html
+++ b/frontend/pages/profile.html
@@ -36,6 +36,9 @@
     <a href="app.html" class="logo">
       <img style="height: 40px" src="../assets/images/biblioDrift_favicon.png" alt="BiblioDrift Logo"> BiblioDrift
     </a>
+    <button class="mobile-menu-toggle" id="mobileMenuToggle" aria-label="Toggle navigation">
+      <i class="fa-solid fa-bars"></i>
+    </button>
     <div class="header-controls">
       <div class="search-bar">
         <input type="text" id="searchInput" class="search-input" placeholder="Search for a feeling...">

--- a/frontend/pages/terms-and-conditions.html
+++ b/frontend/pages/terms-and-conditions.html
@@ -37,6 +37,9 @@
     <a href="index.html" class="logo">
       <img style="height: 40px" src="../assets/images/biblioDrift_favicon.png" alt="BiblioDrift Logo"> BiblioDrift
     </a>
+    <button class="mobile-menu-toggle" id="mobileMenuToggle" aria-label="Toggle navigation">
+      <i class="fa-solid fa-bars"></i>
+    </button>
     <div class="header-controls">
       <div class="search-bar">
         <input type="text" id="searchInput" class="search-input" placeholder="Search for a feeling...">

--- a/frontend/pages/vault.html
+++ b/frontend/pages/vault.html
@@ -34,7 +34,8 @@
   <!-- Added SEO meta description to improve search engine discoverability and click-through rates -->
   <meta name="description" content="BiblioDrift — Discover books by mood, track your reading journey, and get AI-powered recommendations." />
   <title>BiblioDrift | Find yourself in the pages</title>
-  <link rel="stylesheet" href="../css/style.css" />
+  <link rel="stylesheet" href="../css/style.css?v=2" />
+  <link rel="stylesheet" href="../css/style-responsive.css?v=2" />
   <link rel="stylesheet" href="../css/keyboard-shortcuts.css" />
   <link rel="manifest" href="/manifest.json">
   <!-- Fonts -->
@@ -509,6 +510,9 @@
     <a href="app.html" class="logo">
       <img style="height: 40px" src="../assets/images/biblioDrift_favicon.png" alt="BiblioDrift Logo"> BiblioDrift
     </a>
+    <button class="mobile-menu-toggle" id="mobileMenuToggle" aria-label="Toggle navigation">
+      <i class="fa-solid fa-bars"></i>
+    </button>
     <div class="header-controls">
       <div class="search-bar">
         <input type="text" id="searchInput" class="search-input" placeholder="Search for a feeling...">


### PR DESCRIPTION
## Overview
This PR resolves a critical responsive design failure in the global header navigation on mobile viewports. Previously, instead of collapsing into a mobile-appropriate pattern (e.g., a hamburger menu), the header attempted to render all desktop navigation items in a single, un-wrapping row, resulting in severe element overlapping, illegible text, and unusable touch targets.

## Key Changes
* **Hamburger Menu Implementation:** Replaced the un-wrapping horizontal row with a functional, mobile-appropriate collapsible hamburger menu (`.mobile-menu-toggle`) that appears on screens < 768px.
* **Global JavaScript Toggle Fix:** Migrated the mobile menu toggle logic into `pwa.js` (a globally loaded script) to ensure the hamburger menu successfully expands and collapses on all interior app pages (e.g., `app.html`, `chat.html`, `vault.html`).
* **CSS Layout Overflow Resolution:** Added `grid-template-columns: 1fr;` to core grid containers to fix horizontal viewport overflow that was causing text to be chopped off and buttons to stretch unreadably.
* **CSS Syntax Repair:** Fixed a missing closing brace in `style-responsive.css` that was causing browsers to ignore the mobile media queries.
* **Cache Busting:** Appended `?v=2` query parameters to stylesheets and scripts to force browsers to load the updated responsive design immediately, circumventing persistent cache issues.

## Steps to Reproduce & Verify
1. Pull the branch and run the application.
2. View the application on a mobile device or simulate a mobile viewport using browser Developer Tools (width < 768px).
3. Observe the global header navigation bar at the top of the viewport.
**Expected Results:** The header elements successfully wrap/hide, and a hamburger menu is present. Clicking the menu expands the links into large, accessible touch targets without any horizontal overlap or bleeding text.

## ScreenShots
<img width="505" height="750" alt="image" src="https://github.com/user-attachments/assets/74713c47-e773-42d0-bfe8-a8b52da1bff5" />
<img width="568" height="173" alt="image" src="https://github.com/user-attachments/assets/9ad1fd17-c696-43b6-98f2-a172df359f4c" />

closes #854
