### PR TITLE
[GSSoC'26] docs: adding SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security Policy
+
+Thanks for helping make BiblioDrift safe for everyone.
+
+## Supported Versions
+
+We actively support the latest version of BiblioDrift available on the `main` branch.
+
+## Reporting a Vulnerability
+
+If you believe you have found a security vulnerability in BiblioDrift:
+
+* Use GitHub's Report a Vulnerability feature.
+* Contact the maintainers privately.
+
+**Please do not report security vulnerabilities through public issues, discussions, or pull requests.**
+
+Include as much of the information listed below as you can to help us better understand and resolve the issue:
+
+* The type of issue.
+* Full paths of source file(s) related to the issue.
+* The location of the affected source code (tag/branch/commit or direct URL).
+* Step-by-step instructions to reproduce the issue.
+* Proof-of-concept (if possible).
+* Suggested remediation (optional).
+
+This information will help us triage your report more quickly.
+
+## What to Expect
+
+After receiving a report, maintainers will:
+
+* Acknowledge receipt of the report.
+* Investigate and validate the issue.
+* Work on a fix if the vulnerability is confirmed.
+* Coordinate disclosure with the reporter when appropriate.
+
+Response times may vary depending on maintainer availability.
+
+## Disclosure Policy
+
+We appreciate responsible disclosure and ask that reporters avoid publicly disclosing vulnerabilities until a fix has been made available.


### PR DESCRIPTION
## Description
This PR adds the SECURITY.md file to help people disclose security vulnerabilities in a responsible manner.

## Related Issue
Fixes #767 

## Type of Change
- [ ] Bug Fix  
- [ ] Feature  
- [ ] Enhancement  
- [x] Documentation  

## Checklist
- [ ] Code follows guidelines  
- [ ] Tested properly  
- [x] Docs updated  
- [x] PR title includes the relevant event tag or a general contribution label
