### PR TITLE
fix: hide password reset token responses

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2015,8 +2015,8 @@ def forgot_password(validated_data):
         email_config = app_config.email
 
         if plain_token:
-            reset_url = build_password_reset_url(plain_token, frontend_base)
             if is_email_configured(email_config):
+                reset_url = build_password_reset_url(plain_token, frontend_base)
                 send_result = send_password_reset_email(
                     validated_data.email,
                     reset_url,
@@ -2029,11 +2029,10 @@ def forgot_password(validated_data):
                         send_result.detail,
                     )
             elif app_config.is_development():
-                response_data["reset_url"] = reset_url
                 logger.info(
-                    "Dev password reset link for %s (email not configured): %s",
+                    "Password reset requested for %s, but email is not configured; "
+                    "no reset URL was returned.",
                     validated_data.email,
-                    reset_url,
                 )
             elif app_config.is_production():
                 logger.warning(

--- a/tests/test_forgot_password_email.py
+++ b/tests/test_forgot_password_email.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import sys
 from unittest.mock import patch
@@ -33,21 +34,27 @@ def test_forgot_password_sends_email_when_configured(
 
 @patch('backend.app.send_password_reset_email')
 @patch('backend.app.is_email_configured', return_value=False)
-def test_forgot_password_dev_reset_url_when_email_disabled(
+def test_forgot_password_dev_response_hides_reset_token_when_email_disabled(
     _mock_configured,
     mock_send,
     client,
     test_user,
     monkeypatch,
+    caplog,
 ):
     monkeypatch.setenv('APP_ENV', 'development')
-    res = client.post(
-        '/api/v1/auth/forgot-password',
-        json={'email': test_user.email},
-    )
+    with patch('backend.app.request_password_reset', return_value='plain-reset-token'):
+        with caplog.at_level(logging.INFO, logger='backend.app'):
+            res = client.post(
+                '/api/v1/auth/forgot-password',
+                json={'email': test_user.email},
+            )
 
     assert res.status_code == 200
     body = res.get_json()
-    assert 'reset_url' in body
-    assert 'token=' in body['reset_url']
+    assert body.get('reset_url') is None
+    assert body.get('message')
+    assert 'plain-reset-token' not in str(body)
+    assert 'plain-reset-token' not in caplog.text
+    assert 'token=' not in caplog.text
     mock_send.assert_not_called()


### PR DESCRIPTION
## Summary
- stop returning development password reset URLs from the forgot-password API response
- avoid logging raw reset-token URLs when email delivery is not configured
- update the forgot-password regression test to assert only the generic response is exposed

## Validation
- python3 -m py_compile tests/test_forgot_password_email.py backend/app.py
- git diff --check
- Targeted pytest collection is blocked locally by repo environment requirements: native libmagic is unavailable and the checkout uses Python 3.10+ union syntax while this machine has Python 3.9.

Fixes #1059