### PR TITLE
fix(security): apply ProxyFix for correct client IP resolution

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -129,6 +129,11 @@ except ImportError:
 # to ensure API integrity across all origins.
 # =====================================================================
 app = Flask(__name__, static_folder='.', static_url_path='')
+
+# Apply ProxyFix to correctly resolve client IP behind Nginx/reverse proxy
+from werkzeug.middleware.proxy_fix import ProxyFix
+app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_prefix=1)
+
 app.register_blueprint(reader_identity_bp)
 
 # Validate required environment variables at startup


### PR DESCRIPTION
## Summary
Closes #1188

This PR fixes a bug where `request.remote_addr` evaluates to the reverse proxy IP (like Nginx) rather than the actual user's IP. By wrapping the application in `ProxyFix`, `request.remote_addr` now securely reads the `X-Forwarded-For` header, ensuring that rate-limiting and logging operate per-user rather than cumulatively for all traffic.

### Changes
- Added `werkzeug.middleware.proxy_fix.ProxyFix` to `app.wsgi_app`.