### PR TITLE
apply full hardened headers to global 500 handlers

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -544,11 +544,11 @@ def handle_unhandled_exception(e):
     # 8. Return the Secure JSON Response
     # Always return a 500 Internal Server Error status code for unhandled exceptions.
     response = jsonify(response_data)
-    
-    # Adding security headers to error responses as defense in depth
-    response.headers['X-Content-Type-Options'] = 'nosniff'
-    response.headers['X-Frame-Options'] = 'DENY'
-    
+
+    # Ensure the full hardened header set is applied consistently
+    # (including CSP/HSTS/etc.) even for global 500 handlers.
+    response = _apply_security_headers(response)
+
     return response, 500
 
 # =========================================================================
@@ -625,8 +625,11 @@ def handle_sqlalchemy_exception(e):
         }
         
     response = jsonify(response_data)
-    response.headers['X-Content-Type-Options'] = 'nosniff'
-    response.headers['X-Frame-Options'] = 'DENY'
+
+    # Ensure the full hardened header set is applied consistently
+    # (including CSP/HSTS/etc.) even for global 500 handlers.
+    response = _apply_security_headers(response)
+
     return response, 500
 
 # =========================================================================

--- a/tests/test_security_headers_500.py
+++ b/tests/test_security_headers_500.py
@@ -1,0 +1,64 @@
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'backend'))
+from app import app
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as test_client:
+        yield test_client
+
+
+def _assert_full_security_headers(response):
+    assert response.status_code == 500
+
+    # Core hardened headers (must match _apply_security_headers)
+    assert response.headers['Content-Security-Policy'].startswith("default-src 'self'")
+    assert "frame-ancestors 'none'" in response.headers['Content-Security-Policy']
+    assert response.headers['Strict-Transport-Security'] == 'max-age=31536000; includeSubDomains'
+    assert response.headers['X-Content-Type-Options'] == 'nosniff'
+    assert response.headers['Referrer-Policy'] == 'strict-origin-when-cross-origin'
+    assert response.headers['Permissions-Policy'] == 'geolocation=(), microphone=(), camera=()'
+    assert response.headers['X-Frame-Options'] == 'DENY'
+
+
+def test_unhandled_exception_returns_full_security_headers(client, monkeypatch):
+    # Force an unhandled exception within a request context
+    def boom():
+        raise Exception('test boom')
+
+    # Temporarily register a route only for this test run
+    endpoint = 'test_unhandled_exception'
+    rule = '/api/v1/test-500-unhandled'
+
+    app.add_url_rule(rule, endpoint, boom, methods=['GET'])
+    try:
+        response = client.get(rule)
+        _assert_full_security_headers(response)
+    finally:
+        # Flask doesn't expose a clean route removal API; rely on TESTING cleanup.
+        # In CI, tests run in a fresh process.
+        pass
+
+
+def test_sqlalchemy_exception_returns_full_security_headers(client):
+    from sqlalchemy.exc import SQLAlchemyError
+
+    endpoint = 'test_sqlalchemy_exception'
+    rule = '/api/v1/test-500-sqlalchemy'
+
+    def db_boom():
+        raise SQLAlchemyError('test sqlalchemy error')
+
+    app.add_url_rule(rule, endpoint, db_boom, methods=['GET'])
+    try:
+        response = client.get(rule)
+        _assert_full_security_headers(response)
+    finally:
+        pass
+


### PR DESCRIPTION
Global 500 error handlers in backend/app.py were returning JSON responses with only a couple security headers set manually. This caused the full hardened security header set (including Content-Security-Policy, Strict-Transport-Security, etc.) to be missing/incomplete on 500 responses.

This PR ensures the full hardened header set produced by _apply_security_headers() is applied to 500 responses returned by:

@app.errorhandler(Exception)
@app.errorhandler(SQLAlchemyError)

## What Changed
backend/app.py

Updated both global 500 handlers to call _apply_security_headers(response) before returning.
Removed the previous partial manual header setting to avoid divergence.
tests/test_security_headers_500.py

Added assertions that 500 responses produced by forced Exception and forced SQLAlchemyError contain the full hardened header set.

## Testing
Added pytest coverage verifying these headers exist on 500 responses.
Run locally (if pytest is installed):

cd BiblioDrift && python3 -m pytest -q

## Security Impact
Consistent defense-in-depth: browsers receive the same CSP/HSTS/etc. policies even when the server returns an error response.

Author: @goyaljiiiiii 
Closes issue: #1204 
