### PR TITLE
fix: hide Edge password reveal icon

### DIFF
--- a/frontend/pages/auth.html
+++ b/frontend/pages/auth.html
@@ -276,6 +276,13 @@
             padding-right: 2.75rem;
         }
 
+        .auth-input[type="password"]::-ms-reveal,
+        .auth-input[type="password"]::-ms-clear {
+            display: none;
+            width: 0;
+            height: 0;
+        }
+
         .auth-input {
             width: 100%;
             min-height: 3.5rem;


### PR DESCRIPTION
## Summary
- hide Microsoft Edge password reveal and clear pseudo-controls on auth password inputs
- keep the existing custom Font Awesome password toggle as the only visible reveal control
- apply the rule to login, signup, and reset password fields through the shared auth input class

## Root Cause
Microsoft Edge injects built-in password reveal UI into password fields. The auth page already has a custom visibility toggle, so Edge can render a duplicate icon inside the same input.

## Changes Made
- added Edge-specific CSS for ::-ms-reveal and ::-ms-clear on auth password inputs
- preserved the existing password toggle JavaScript and layout

## Testing
- npm ci in frontend
- git diff --check
- npm run build currently fails on an existing unrelated CSS syntax error in frontend/css/contributing.css at line 1709: Unclosed block

## Impact
Auth password fields now maintain a consistent single visibility control in Microsoft Edge without affecting other browsers or backend authentication.

Fixes #1172