### PR TITLE
feat: Add constellation background for dark mode [GSSoC'26]

### DIFF
--- a/frontend/js/constellation.js
+++ b/frontend/js/constellation.js
@@ -1,0 +1,119 @@
+(function () {
+  const canvas = document.getElementById('constellationCanvas');
+  if (!canvas) return;
+
+  const ctx = canvas.getContext('2d');
+  const STAR_COUNT = 120;
+  const CONNECTION_DIST = 140;
+  const stars = [];
+
+  function resize() {
+    canvas.width  = window.innerWidth;
+    canvas.height = window.innerHeight;
+  }
+
+  function randomStar() {
+    return {
+      x:     Math.random() * canvas.width,
+      y:     Math.random() * canvas.height,
+      r:     Math.random() * 1.5 + 0.4,
+      alpha: Math.random() * 0.5 + 0.3,
+      dx:    (Math.random() - 0.5) * 0.18,
+      dy:    (Math.random() - 0.5) * 0.18,
+      twinkleSpeed: Math.random() * 0.008 + 0.003,
+      twinkleDir: Math.random() > 0.5 ? 1 : -1,
+    };
+  }
+
+  function init() {
+    resize();
+    stars.length = 0;
+    for (let i = 0; i < STAR_COUNT; i++) stars.push(randomStar());
+  }
+
+  function draw() {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    for (let i = 0; i < stars.length; i++) {
+      for (let j = i + 1; j < stars.length; j++) {
+        const dx = stars[i].x - stars[j].x;
+        const dy = stars[i].y - stars[j].y;
+        const dist = Math.sqrt(dx * dx + dy * dy);
+        if (dist < CONNECTION_DIST) {
+          const lineAlpha = (1 - dist / CONNECTION_DIST) * 0.18;
+          ctx.beginPath();
+          ctx.moveTo(stars[i].x, stars[i].y);
+          ctx.lineTo(stars[j].x, stars[j].y);
+          ctx.strokeStyle = `rgba(212, 175, 55, ${lineAlpha})`;
+          ctx.lineWidth = 0.6;
+          ctx.stroke();
+        }
+      }
+    }
+
+    stars.forEach(s => {
+      ctx.beginPath();
+      ctx.arc(s.x, s.y, s.r, 0, Math.PI * 2);
+      ctx.fillStyle = `rgba(255, 248, 220, ${s.alpha})`;
+      ctx.fill();
+    });
+  }
+
+  function update() {
+    stars.forEach(s => {
+      s.x += s.dx;
+      s.y += s.dy;
+
+      s.alpha += s.twinkleSpeed * s.twinkleDir;
+      if (s.alpha > 0.85 || s.alpha < 0.2) s.twinkleDir *= -1;
+
+      if (s.x < 0) s.x = canvas.width;
+      if (s.x > canvas.width) s.x = 0;
+      if (s.y < 0) s.y = canvas.height;
+      if (s.y > canvas.height) s.y = 0;
+    });
+  }
+
+  let animId = null;
+
+  function loop() {
+    update();
+    draw();
+    animId = requestAnimationFrame(loop);
+  }
+
+  function startConstellation() {
+    if (animId) return;
+    canvas.style.opacity = '1';
+    loop();
+  }
+
+  function stopConstellation() {
+    canvas.style.opacity = '0';
+    if (animId) {
+      cancelAnimationFrame(animId);
+      animId = null;
+    }
+  }
+
+  function checkTheme() {
+    const isNight = document.documentElement.getAttribute('data-theme') === 'night';
+    isNight ? startConstellation() : stopConstellation();
+  }
+
+  const observer = new MutationObserver(checkTheme);
+  observer.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ['data-theme']
+  });
+
+  window.addEventListener('resize', () => {
+    resize();
+    init();
+  });
+
+  if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    init();
+    checkTheme();
+  }
+})();

--- a/frontend/pages/index.html
+++ b/frontend/pages/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
 
-<head>
+<head> 
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script>
@@ -2687,7 +2687,8 @@
             </button>
         </main>
     </div>
-
+    <canvas id="constellationCanvas" style="position:fixed;inset:0;width:100%;height:100%;pointer-events:none;z-index:0;opacity:0;transition:opacity 1.2s ease;"></canvas>
+    <script src="../js/constellation.js"></script>
     <script src="../js/theme-manager.js"></script>
     <script src="../js/landing-interactions.js"></script>
     <script src="../js/ambient.js"></script>


### PR DESCRIPTION
# Pull Request

## Description
Added a constellation animation that appears as a background when dark mode (night theme) is toggled on, and fades out when switching back to light mode.

## Related Issue
Fixes #1182 

## Type of Change
- [ ] Bug Fix
- [x] Feature
- [ ] Enhancement
- [ ] Documentation

## Testing
- Toggled dark mode on ,constellations appear with twinkling stars and golden connecting lines
- Toggled dark mode off , constellations fade out smoothly
- Tested on mobile viewport ,responsive and performant
- Respects prefers-reduced-motion accessibility setting

## Screenshots
(attach a screenshot of dark mode with constellations visible)

## Checklist
- [x] Code follows guidelines
- [x] Tested properly
- [ ] Docs updated
- [x] PR title includes the relevant event tag or a general contribution label

[GSSoC'26] Add constellation background for dark mode