### PR TITLE
Fix(Enhancement): navbar proper spacing on clicking "My library" nav-link

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -261,6 +261,7 @@ header {
     backdrop-filter: blur(25px);
     -webkit-backdrop-filter: blur(25px);
     border-bottom: 1px solid rgba(0, 0, 0, 0.15);
+    gap:1rem;
     /* Subtly deeper bottom border */
     transition: background-color 0.4s ease, color 0.4s ease, backdrop-filter 0.4s ease, border-color 0.4s ease;
 }
@@ -354,6 +355,7 @@ header {
     display: flex;
     align-items: center;
     gap: 0.5rem;
+    flex: 0 0 auto;
 }
 
 .nav-links {


### PR DESCRIPTION
# Pull Request

If this PR is for an open source event such as NSoC'26, Apertre 3.0, or GSSoC'26, mention that in the title or description. If not, treat it as a general contribution.

## Description
Describe your changes.

This PR is for GSSoC'26 which is improving the UI of navbars. 
The problem was that the search bar is superimposing the "BiblioDrift" logo on clicking "My Library" nav-link making the both elements congested and not visible properly.
The changes made in the code are setting flex properties of logo and nav-links in style.css page so that they do not superimpose on each other ( no shrink or grow-fixed layout) on clicking nav-links.

## Related Issue
Fixes #1237 

## Type of Change
- [ ] Bug Fix  
- [ ] Feature  
- [X ] Enhancement  
- [ ] Documentation  

## Testing
Explain how you tested it.
Since, there are only property changes in css file, no interruption is made in backend. The code runs successfully. The before and after screenshots are attached as successfulness of testing.



## Screenshots
(if applicable)
<img width="1304" height="102" alt="Screenshot 2026-06-07 134353" src="https://github.com/user-attachments/assets/d344feb1-544a-42ad-ae19-5dc483f388b9" />
<img width="1262" height="91" alt="Screenshot 2026-06-07 134418" src="https://github.com/user-attachments/assets/5fcb9059-6bc9-4bd9-bbc1-ec663b6ebd8d" />
## Checklist
- [X ] Code follows guidelines  
- [ X] Tested properly  
- [ X] Docs updated  
- [X ] PR title includes the relevant event tag or a general contribution label

GSSoC'26