### PR TITLE
fix: navbar sticky visibility + correct venv verification command (closes #1240, closes #1270)

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -61,7 +61,7 @@ Before you begin, make sure you are familiar with the current stack:
    ```
    Verify virtual environment is active:
    ```bash
-   python --version
+   where python
    ```
    Your terminal should now show `(.venv)` at the beginning.
 5. Setting up pip:
@@ -127,3 +127,4 @@ If label automation is enabled in the repository, `gssoc:approved` is added when
 ## License
 
 By contributing, you agree that your contributions will be licensed under the project’s MIT License.
+

--- a/frontend/css/landing.css
+++ b/frontend/css/landing.css
@@ -74,9 +74,7 @@ body.landing-page .landing-shell {
     padding: 1rem 0 0;
 }
 
-.landing-header {
-    position: sticky;
-    top: 1rem;
+.landing-header { position: sticky; top: 0;
     z-index: 12;
     display: flex;
     align-items: center;
@@ -1944,3 +1942,4 @@ html[data-theme='night'] .hero-book-stack::before {
     background: rgba(255, 255, 255, 0.05);
     border-color: rgba(255, 255, 255, 0.1);
 }
+


### PR DESCRIPTION
## Summary

Two small fixes:

### 1. Navbar stays visible while scrolling (closes #1240)
The `.landing-header` had `top: 1rem` instead of `top: 0`, causing a visible gap and inconsistent sticky behavior. Changed to `top: 0` to keep the navbar fully visible at the top of the viewport while scrolling.

### 2. Correct venv verification command (closes #1270)
`docs/contributing.md` step 5 used `python --version` to verify virtual environment activation. This is misleading — it only shows the Python version, not whether the venv is active. Replaced with `where python` which shows the actual Python executable path, confirming venv activation.

## Changes
- `frontend/css/landing.css`: `.landing-header top: 1rem` → `top: 0`
- `docs/contributing.md`: `python --version` → `where python`

Closes #1240
Closes #1270