### PR TITLE
fix: genre books modal responsive on mobile devices (closes #573)

### DIFF
--- a/frontend/css/style-responsive.css
+++ b/frontend/css/style-responsive.css
@@ -500,6 +500,8 @@ input {
         max-height: 90vh;
         margin: 2rem auto;
         border-radius: 16px;
+        overflow-y: auto;
+        overflow-x: hidden;
     }
 
     .genre-modal-header {
@@ -511,6 +513,22 @@ input {
 
     .genre-modal-header h2 {
         font-size: 1.5rem;
+    }
+
+    .genre-books-grid {
+        grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+        gap: 1rem;
+        padding: 0.5rem;
+    }
+
+    .genre-book-card {
+        max-width: 100%;
+    }
+
+    .genre-book-card img {
+        width: 100%;
+        height: auto;
+        object-fit: contain;
     }
 
     .genre-books-grid {


### PR DESCRIPTION
Fixed genre books modal not being responsive on mobile:

- Added `overflow-y: auto` and `overflow-x: hidden` to `.genre-modal-content` so book covers scroll vertically instead of getting clipped
- Added responsive grid rules: `.genre-books-grid` uses `grid-template-columns: repeat(auto-fill, minmax(140px, 1fr))` for mobile
- Added `.genre-book-card` max-width and `.genre-book-card img` responsive sizing to prevent overflow

Closes #573