### PR TITLE
fix: Multiple UI/UX improvements (GSSoC'26)

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -61,7 +61,11 @@ Before you begin, make sure you are familiar with the current stack:
    ```
    Verify virtual environment is active:
    ```bash
-   python --version
+   # Windows — should show path inside .venv
+   where python
+   
+   # Linux/macOS
+   which python
    ```
    Your terminal should now show `(.venv)` at the beginning.
 5. Setting up pip:

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -8254,3 +8254,109 @@ dialog.book-preview-modal::backdrop {
         font-size: 0.95rem;
     }
 }
+
+/* ============================================================
+   GSSoC FIXES — Scroll-to-top, dark mode, contrast improvements
+   ============================================================ */
+
+/* Scroll-to-top floating button (#1111) */
+.scroll-top-btn {
+    position: fixed;
+    bottom: 2rem;
+    right: 2rem;
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    background: var(--accent-gold, #d4af37);
+    color: #1a1a1a;
+    border: none;
+    cursor: pointer;
+    font-size: 1.4rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 4px 15px rgba(0,0,0,0.2);
+    z-index: 999;
+    opacity: 0;
+    transform: translateY(20px);
+    transition: opacity 0.3s ease, transform 0.3s ease;
+    pointer-events: none;
+}
+.scroll-top-btn.visible {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+}
+.scroll-top-btn:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 6px 20px rgba(0,0,0,0.3);
+}
+
+/* Constellation stars for dark mode (#1182) */
+[data-theme="night"] body::before {
+    content: '';
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 0;
+    background-image: 
+        radial-gradient(1px 1px at 10% 15%, rgba(255,255,255,0.4), transparent),
+        radial-gradient(1px 1px at 25% 8%, rgba(255,255,255,0.3), transparent),
+        radial-gradient(1.5px 1.5px at 40% 20%, rgba(255,255,255,0.5), transparent),
+        radial-gradient(1px 1px at 55% 12%, rgba(255,255,255,0.35), transparent),
+        radial-gradient(1px 1px at 70% 18%, rgba(255,255,255,0.4), transparent),
+        radial-gradient(1.5px 1.5px at 85% 10%, rgba(255,255,255,0.45), transparent),
+        radial-gradient(1px 1px at 15% 25%, rgba(255,255,255,0.3), transparent),
+        radial-gradient(1px 1px at 60% 22%, rgba(255,255,255,0.35), transparent),
+        radial-gradient(1px 1px at 90% 15%, rgba(255,255,255,0.25), transparent);
+}
+
+/* Contributors page dark mode fixes (#1124) */
+[data-theme="night"] .contributor-card,
+[data-theme="night"] .contributor-item {
+    color: var(--text-main);
+    background: var(--card-bg, rgba(30, 30, 30, 0.8));
+}
+[data-theme="night"] .contributor-card h3,
+[data-theme="night"] .contributor-card .contributor-name,
+[data-theme="night"] .contributor-item .contributor-name {
+    color: #fffdf9;
+}
+[data-theme="night"] .contributor-card p,
+[data-theme="night"] .contributor-card .contributor-stats,
+[data-theme="night"] .contributor-item .contributor-stats {
+    color: rgba(255,255,255,0.75);
+}
+
+/* Improved visibility for auto-refresh status button (#1265) */
+.auto-refresh-status,
+[data-refresh-status] {
+    background: rgba(212, 175, 55, 0.2) !important;
+    color: var(--accent-gold, #d4af37) !important;
+    border: 1px solid rgba(212, 175, 55, 0.3) !important;
+    font-weight: 600;
+}
+[data-theme="night"] .auto-refresh-status,
+[data-theme="night"] [data-refresh-status] {
+    background: rgba(212, 175, 55, 0.15) !important;
+    color: #f0d060 !important;
+    border: 1px solid rgba(212, 175, 55, 0.4) !important;
+}
+
+/* Ensure yellow/gold text has sufficient contrast (#1200) */
+.yellow-text,
+.gold-text,
+.text-gold,
+[class*="yellow"],
+[style*="color: #d4af37"],
+[style*="color:#d4af37"] {
+    color: #b8941f !important;
+}
+[data-theme="night"] .yellow-text,
+[data-theme="night"] .gold-text,
+[data-theme="night"] .text-gold {
+    color: #f0d060 !important;
+}

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -2293,6 +2293,7 @@ textarea:focus {
     line-clamp: 2;
     -webkit-box-orient: vertical;
     overflow: hidden;
+    text-shadow: 0 1px 3px rgba(0,0,0,0.5);
 }
 
 .book-rec-info p {
@@ -2303,6 +2304,7 @@ textarea:focus {
     line-clamp: 1;
     -webkit-box-orient: vertical;
     overflow: hidden;
+    text-shadow: 0 1px 2px rgba(0,0,0,0.4);
 }
 
 /* Emotion Tags & Mood Filtering */
@@ -5819,6 +5821,11 @@ textarea:focus {
 /* Fancy focus */
 .sort-select:focus {
     color: var(--accent-gold);
+}
+
+/* Hide native select dropdown arrow in IE/Edge to prevent double arrows */
+.sort-select::-ms-expand {
+    display: none;
 }
 
 .filter-group::after {

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -4766,3 +4766,25 @@ async function handleResetPassword(event) {
 }
 
 window.handleResetPassword = handleResetPassword;
+
+// Scroll-to-top button (#1111)
+(function() {
+    const btn = document.createElement('button');
+    btn.className = 'scroll-top-btn';
+    btn.innerHTML = '&#8593;';
+    btn.setAttribute('aria-label', 'Scroll to top');
+    btn.title = 'Back to top';
+    document.body.appendChild(btn);
+    
+    btn.addEventListener('click', function() {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+    
+    window.addEventListener('scroll', function() {
+        if (window.scrollY > 300) {
+            btn.classList.add('visible');
+        } else {
+            btn.classList.remove('visible');
+        }
+    });
+})();

--- a/frontend/pages/auth.html
+++ b/frontend/pages/auth.html
@@ -545,6 +545,16 @@
             20%, 60% { transform: translateX(-5px); border-color: #f87171; }
             40%, 80% { transform: translateX(5px); border-color: #f87171; }
         }
+
+        /* Prevent Edge browser's built-in password reveal icon from overlapping custom toggle */
+        .auth-input[type="password"]::-ms-reveal,
+        .auth-input[type="password"]::-ms-reveal {
+            display: none;
+        }
+        /* Also hide for other browsers */
+        input[type="password"]::-ms-reveal {
+            display: none;
+        }
     </style>
     <link rel="icon" href="../assets/images/biblioDrift_favicon.png" type="image/png">
     <!-- PWA -->

--- a/frontend/pages/index.html
+++ b/frontend/pages/index.html
@@ -1967,15 +1967,15 @@
                     </div>
                     <div class="hero-metrics" aria-label="Project highlights">
                         <article class="metric-card reveal" data-delay="1">
-                            <strong data-count="4">0</strong>
+                            <strong data-count="4">4</strong>
                             <span>cozy reading moods</span>
                         </article>
                         <article class="metric-card reveal" data-delay="2">
-                            <strong data-count="3">0</strong>
+                            <strong data-count="3">3</strong>
                             <span>core app spaces</span>
                         </article>
                         <article class="metric-card reveal" data-delay="3">
-                            <strong data-count="100">0</strong>
+                            <strong data-count="100">100</strong>
                             <span>responsive design</span>
                         </article>
                     </div>

--- a/frontend/pages/privacy-policy.html
+++ b/frontend/pages/privacy-policy.html
@@ -355,6 +355,18 @@
           flex-direction: column;
         }
       }
+
+      /* Privacy page navbar fixes — prevent search bar crowding the logo */
+      header {
+        gap: 1.5rem;
+      }
+      header .logo {
+        flex-shrink: 0;
+      }
+      /* Align breadcrumb properly below header */
+      .breadcrumb {
+        margin-top: 0.5rem;
+      }
     </style>
   </head>
 


### PR DESCRIPTION
## Description

This PR addresses **10 open issues** under GSSoC'26, improving UI/UX, accessibility, and documentation across BiblioDrift.

### Issues Fixed

- closes #1172 — Hide Edge browser's built-in password reveal icon overlapping custom toggle
- closes #1182 — Add subtle constellation star effect in dark mode
- closes #1124 — Fix contributor card text contrast in dark mode
- closes #1111 — Add floating scroll-to-top button (appears after 300px scroll)
- closes #1265 — Improve auto-refresh status button contrast with gold accents
- closes #1200 — Fix low-contrast yellow/gold text visibility
- closes #1270 — Fix virtual environment verification command in contributing guide
- closes #1167 — Fix privacy page navbar logo/search bar crowding and breadcrumb alignment
- closes #1141 — Hide native select dropdown arrow to prevent duplicate arrows on library page
- closes #1256 — Add text-shadow to book recommendation overlay text for readability over bright covers
- closes #1191 — Homepage stat counters now display real data-count values instead of hardcoded "0"

### Files Changed

| File | Changes |
|------|---------|
| `frontend/pages/auth.html` | Hide Edge ::-ms-reveal password icon |
| `frontend/pages/privacy-policy.html` | Navbar spacing fixes, breadcrumb alignment |
| `frontend/pages/index.html` | Stat counters display real values |
| `frontend/css/style.css` | Dark mode stars, contributor fixes, scroll-to-top, refresh visibility, yellow text, select arrows, book overlay text-shadow |
| `frontend/js/app.js` | Scroll-to-top button JS logic |
| `docs/contributing.md` | Fix venv verification command |

### Notes

- All CSS additions appended at end of style.css to minimize merge conflicts
- Dark mode changes use `[data-theme="night"]` selectors, no impact on light mode
- No backend modifications, frontend-only changes

Happy to make any adjustments. Thank you for reviewing!
