### PR TITLE
fix: header responsive layout + book recommendation card overflow (closes #599, closes #514)

### DIFF
--- a/frontend/css/style-responsive.css
+++ b/frontend/css/style-responsive.css
@@ -500,6 +500,8 @@ input {
         max-height: 90vh;
         margin: 2rem auto;
         border-radius: 16px;
+        overflow-y: auto;
+        overflow-x: hidden;
     }
 
     .genre-modal-header {
@@ -511,6 +513,22 @@ input {
 
     .genre-modal-header h2 {
         font-size: 1.5rem;
+    }
+
+    .genre-books-grid {
+        grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+        gap: 1rem;
+        padding: 0.5rem;
+    }
+
+    .genre-book-card {
+        max-width: 100%;
+    }
+
+    .genre-book-card img {
+        width: 100%;
+        height: auto;
+        object-fit: contain;
     }
 
     .genre-books-grid {

--- a/frontend/css/style-responsive.css
+++ b/frontend/css/style-responsive.css
@@ -531,6 +531,67 @@ input {
         object-fit: contain;
     }
 
+    /* Header responsive — prevent element overlap */
+    header {
+        padding: 0.8rem 1rem;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+    }
+
+    .header-controls {
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        width: 100%;
+        justify-content: flex-end;
+    }
+
+    .nav-links {
+        gap: 0.75rem;
+        flex-wrap: wrap;
+    }
+
+    .nav-links a {
+        font-size: 0.85rem;
+        padding: 0.3rem 0.5rem;
+        min-height: 28px;
+    }
+
+    header .logo {
+        font-size: 1rem;
+    }
+
+    header .logo img {
+        height: 28px;
+    }
+
+    /* Book recommendation card overflow fix */
+    .book-rec-item {
+        min-width: 0;
+        word-break: break-word;
+        overflow-wrap: break-word;
+        padding: 8px;
+    }
+
+    .book-rec-grid {
+        grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+        gap: 8px;
+    }
+
+    .book-rec-info h4 {
+        font-size: 0.75rem;
+        line-height: 1.3;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+    }
+
+    .book-rec-cover {
+        width: 48px;
+        height: 72px;
+    }
+
     .genre-books-grid {
         grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
         gap: 0.75rem;


### PR DESCRIPTION
## Summary

Two CSS fixes in style-responsive.css:

### Header Responsiveness (closes #599)
- Header now wraps properly on mobile with `flex-wrap` and reduced padding
- `.header-controls` wraps and uses full width on small screens
- `.nav-links` uses smaller gaps and wraps
- Logo and nav link font sizes reduced for mobile

### Book Recommendation Card Overflow (closes #514)
- `.book-rec-item`: added `min-width: 0`, `word-break: break-word`, `overflow-wrap: break-word` to prevent text overflow
- `.book-rec-grid`: reduced min column width from 120px to 100px for better mobile fit
- `.book-rec-info h4`: added `text-overflow: ellipsis` with 2-line clamp to handle long titles
- `.book-rec-cover`: reduced size for mobile

Closes #599
Closes #514