### PR TITLE
fix(security): add JWT auth to generate-note endpoint

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1195,6 +1195,7 @@ def handle_purchase_links():
         return internal_error(str(e))
 
 @app.route('/api/v1/generate-note', methods=['POST'])
+@jwt_required()
 @limiter.limit("10 per minute")
 @validate_schema(GenerateNoteRequest)
 def handle_generate_note(validated_data):


### PR DESCRIPTION
## Summary
The /api/v1/generate-note endpoint was missing authentication, allowing unauthenticated users to consume AI API credits without any authorization check.

## Changes
- Added @jwt_required() decorator to the generate-note endpoint
- Now rejects unauthenticated requests with 401
- Prevents unauthorized credit drain via the AI note generation API

## Issue
Closes #1281