### PR TITLE
fix(security): add MAX_CONTENT_LENGTH to prevent request size bypass

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -131,6 +131,11 @@ except ImportError:
 app = Flask(__name__, static_folder='.', static_url_path='')
 app.register_blueprint(reader_identity_bp)
 
+# Security: Set hard limit on request body size to prevent content-length spoofing
+# This catches chunked transfer encoding attacks where Content-Length is omitted
+# or spoofed. Flask enforces this at the WSGI level before the request body is read.
+app.config['MAX_CONTENT_LENGTH'] = 5 * 1024 * 1024  # 5MB hard limit
+
 # Validate required environment variables at startup
 # This will raise ValueError if any required variables are missing
 validate_required_env_vars()


### PR DESCRIPTION
## Summary
The request size validation relied solely on request.content_length which can be spoofed or omitted via chunked Transfer-Encoding. Added Flask-level MAX_CONTENT_LENGTH (5MB) as a hard enforcement layer.

## Changes
- Added app.config['MAX_CONTENT_LENGTH'] = 5 * 1024 * 1024
- Flask enforces this at the WSGI level before reading the body
- Catches chunked transfer encoding attacks where Content-Length is omitted

## Issue
Closes #1280