### PR TITLE
fix(chat): add socket connection timeout and error handling

### DIFF
--- a/frontend/js/chat.js
+++ b/frontend/js/chat.js
@@ -23,7 +23,19 @@ class ChatInterface {
         if (typeof io !== 'undefined') {
             const moodApiBase = window.MOOD_API_BASE || 'http://127.0.0.1:5000';
             const baseUrl = moodApiBase.replace(/\/api\/v1\/?$/, '');
-            this.socket = io(baseUrl);
+            this.socket = io(baseUrl, {
+                timeout: 10000,
+                reconnectionAttempts: 5,
+                reconnectionDelay: 1000
+            });
+            
+            this.socket.on('connect_error', (error) => {
+                console.warn('Chat socket connection failed:', error.message);
+            });
+            
+            this.socket.on('reconnect_failed', () => {
+                console.warn('Chat socket reconnection failed after all attempts');
+            });
             
             this.socket.on('chat_stream', (data) => {
                 if (this.currentMessageBubble) {


### PR DESCRIPTION
## Summary
The Socket.IO connection in the chat interface had no timeout or error handling, causing the UI to hang indefinitely on connection failures.

## Changes
- Added 10-second connection timeout
- Added reconnection limit (5 attempts with 1s delay)
- Added connect_error and reconnect_failed event handlers
- Prevents infinite loading state on connection failures