### PR TITLE
fix(cors): add OPTIONS preflight handler for API endpoints

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -288,6 +288,13 @@ socketio = SocketIO(app, cors_allowed_origins=_cors_origins)
 # Initialize cache service
 cache_service.init_app(app)
 
+# ---- CORS Preflight Handler ----
+@app.before_request
+def handle_preflight():
+    """Handle CORS preflight OPTIONS requests before they hit rate limiters or auth checks."""
+    if request.method == 'OPTIONS' and request.path.startswith('/api/'):
+        return app.make_default_options_response()
+
 
 def _resolve_rate_limit_principal() -> str:
     """Resolve a stable principal for per-user/session throttling."""


### PR DESCRIPTION
## Summary
Browser CORS preflight requests (OPTIONS) were being processed through the full middleware chain including rate limiters, auth checks, and schema validators, causing unnecessary overhead.

## Changes
- Added before_request handler that returns early for OPTIONS requests on /api/* paths
- Prevents preflight requests from consuming rate limit quotas
- Avoids unnecessary JWT/schema validation on CORS preflight