### PR TITLE
feat(a11y): add noscript fallback to main HTML pages

### DIFF
--- a/frontend/pages/app.html
+++ b/frontend/pages/app.html
@@ -94,6 +94,13 @@
 </head>
 
 <body>
+    <noscript>
+        <div style="padding:2rem;text-align:center;background:#2c2420;color:#f9f7f2;font-family:sans-serif;">
+            <h2>JavaScript Required</h2>
+            <p>BiblioDrift requires JavaScript for its full functionality.</p>
+            <p>Please enable JavaScript in your browser settings.</p>
+        </div>
+    </noscript>
   <div id="sc-glow-outer"></div>
   <div id="sc-glow-mid"></div>
   <div id="sc-glow-inner"></div>

--- a/frontend/pages/auth.html
+++ b/frontend/pages/auth.html
@@ -557,6 +557,13 @@
 </head>
 
 <body class="auth-page">
+    <noscript>
+        <div style="padding:2rem;text-align:center;background:#2c2420;color:#f9f7f2;font-family:sans-serif;">
+            <h2>JavaScript Required</h2>
+            <p>BiblioDrift requires JavaScript for its full functionality.</p>
+            <p>Please enable JavaScript in your browser settings.</p>
+        </div>
+    </noscript>
     <header>
         <a href="app.html" class="logo">
             <img style="height: 40px" src="../assets/images/biblioDrift_favicon.png" alt="BiblioDrift Logo"> BiblioDrift

--- a/frontend/pages/chat.html
+++ b/frontend/pages/chat.html
@@ -304,6 +304,13 @@
 </head>
 
 <body>
+    <noscript>
+        <div style="padding:2rem;text-align:center;background:#2c2420;color:#f9f7f2;font-family:sans-serif;">
+            <h2>JavaScript Required</h2>
+            <p>BiblioDrift requires JavaScript for its full functionality.</p>
+            <p>Please enable JavaScript in your browser settings.</p>
+        </div>
+    </noscript>
       <header>
     <a href="app.html" class="logo">
       <img style="height: 40px" src="../assets/images/biblioDrift_favicon.png" alt="BiblioDrift Logo"> BiblioDrift

--- a/frontend/pages/index.html
+++ b/frontend/pages/index.html
@@ -1922,6 +1922,13 @@
 </head>
 
 <body class="landing-page">
+    <noscript>
+        <div style="padding:2rem;text-align:center;background:#2c2420;color:#f9f7f2;font-family:sans-serif;">
+            <h2>JavaScript Required</h2>
+            <p>BiblioDrift requires JavaScript to provide an interactive reading discovery experience.</p>
+            <p>Please enable JavaScript in your browser settings.</p>
+        </div>
+    </noscript>
     <div id="sc-glow-outer"></div>
     <div id="sc-glow-mid"></div>
     <div id="sc-glow-inner"></div>

--- a/frontend/pages/library.html
+++ b/frontend/pages/library.html
@@ -51,6 +51,13 @@
 </head>
 
 <body class="library-page">
+    <noscript>
+        <div style="padding:2rem;text-align:center;background:#2c2420;color:#f9f7f2;font-family:sans-serif;">
+            <h2>JavaScript Required</h2>
+            <p>BiblioDrift requires JavaScript for its full functionality.</p>
+            <p>Please enable JavaScript in your browser settings.</p>
+        </div>
+    </noscript>
     <div id="sc-glow-outer"></div>
     <div id="sc-glow-mid"></div>
     <div id="sc-glow-inner"></div>


### PR DESCRIPTION
## Summary
The main user-facing HTML pages had no fallback content for browsers with JavaScript disabled, leaving users with a blank or broken experience.

## Changes
- Added <noscript> tags to index.html, auth.html, library.html, app.html, and chat.html
- Displays a styled message informing users that JavaScript is required
- Improves accessibility and user experience for non-JS environments