### PR TITLE
fix(library): deduplicate sync items to prevent duplicate book inserts

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1611,6 +1611,18 @@ def sync_library(validated_data):
         # Sanitize the items list only after validating Google Books IDs.
         items = sanitize_payload(validated_data.items)
         
+        # Deduplicate items by Google Books ID to prevent duplicate inserts
+        seen_ids = set()
+        deduped_items = []
+        for item_data in items:
+            if not isinstance(item_data, dict):
+                continue
+            gid = item_data.get('id')
+            if gid and gid not in seen_ids:
+                seen_ids.add(gid)
+                deduped_items.append(item_data)
+        items = deduped_items
+        
         synced_count = 0
         conflicts = 0
         errors = 0


### PR DESCRIPTION
## Summary
The library sync endpoint processed items sequentially without deduplication, risking IntegrityErrors when the same Google Books ID appeared multiple times in a sync payload.

## Changes
- Added set-based deduplication by Google Books ID before database operations
- Filters out duplicate IDs while preserving the first occurrence of each book
- Prevents potential database integrity errors during bulk sync operations