### PR TITLE
[GSSoC'26] Fix: Mood tags overlapping quiz content due to conflicting CSS positioning

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -898,7 +898,7 @@ textarea:focus {
 /* --- Mood Analysis Styles --- */
 
 /* Mood Tags on Book Covers */
-.mood-tags {
+.book__face--front .mood-tags {
     position: absolute;
     top: 5px;
     left: 5px;
@@ -7828,7 +7828,9 @@ body.night-mode .tooltip-author {
     margin-bottom: 1rem;
 }
 
-.mood-tags {
+.quiz-results .mood-tags {
+    position: relative;
+    width: 100%;
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
@@ -7836,7 +7838,7 @@ body.night-mode .tooltip-author {
     margin-bottom: 1.5rem;
 }
 
-.mood-tags span {
+.quiz-results .mood-tags span {
     background: var(--glass-bg);
     border: 1px solid var(--accent-gold);
     color: var(--accent-gold);


### PR DESCRIPTION
# Pull Request

## Description
Fixes a CSS cascade conflict where generated mood tag pills (`#ADVENTUROUS`, `#THRILLER`, etc.) were floating over the quiz questions instead of appearing inside the "Your Reading Mood Tags" section below.

**Root cause:** Two separate rules shared the `.mood-tags` class in `style.css`:
- One rule (line ~901) was intended for book cover overlays and had `position: absolute`
- One rule (line ~7831) was intended for quiz results with flex layout

The quiz result tags were inheriting `position: absolute` from the book cover rule since the second rule never reset it, causing the overlap.

**Fix:** Scoped both rules more specifically so they no longer conflict:
- `.mood-tags` → `.book__face--front .mood-tags` (book cover rule)
- `.mood-tags` → `.quiz-results .mood-tags` with `position: relative` added (quiz rule)
- `.mood-tags span` → `.quiz-results .mood-tags span`

No JavaScript changes were needed.

## Related Issue
Fixes #1312

## Type of Change
- [ ] Bug Fix  
- [x] Feature  
- [x] Enhancement  
- [ ] Documentation  

## Testing
1. Opened `frontend/pages/app.html` in the browser
2. Scrolled to the **Reading Mood Quiz** section
3. Selected an answer for all 4 questions
4. Clicked **Generate Mood Tags**
5. Verified mood tag pills now appear cleanly **inside** the "Your Reading Mood Tags" section below the quiz, with no overlap on the question text
6. Also verified that mood tags on book covers still display correctly with `position: absolute` on the book face

## Screenshots
Before:
<img width="1915" height="957" alt="Screenshot 2026-06-12 134541" src="https://github.com/user-attachments/assets/8e65dd98-4456-4b97-ac87-5c5a585ec13b" />

After: 
<img width="1870" height="900" alt="image" src="https://github.com/user-attachments/assets/e1a96157-fb09-4f02-b267-909859292b2c" />

## Checklist
- [x] Code follows guidelines  
- [x] Tested properly  
- [ ] Docs updated  
- [x] PR title includes the relevant event tag or a general contribution label