### PR TITLE
Enhancement: include missing field names in missing_fields_error response

### DIFF
--- a/backend/core/responses/error_responses.py
+++ b/backend/core/responses/error_responses.py
@@ -4,7 +4,7 @@ This module provides consistent error response formatting across all API endpoin
 """
 
 from flask import jsonify
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, Union, List
 import logging
 
 logger = logging.getLogger(__name__)
@@ -141,12 +141,35 @@ def validation_error(message: str, status_code: int = 400) -> tuple:
     return error_response(ErrorCodes.VALIDATION_ERROR, message, status_code)
 
 
-def missing_fields_error(fields: str) -> tuple:
-    """Return a missing fields error response"""
+def missing_fields_error(fields: Union[str, List[str]]) -> tuple:
+    """
+    Return a missing fields error response.
+
+    Args:
+        fields: The missing field name(s). Accepts either a single string,
+            a comma-separated string, or a list of field names.
+
+    Returns:
+        Tuple of (jsonify response, status_code). The error payload includes
+        a ``missing_fields`` list so consumers can programmatically identify
+        which fields were missing.
+
+    Example:
+        return missing_fields_error(["title", "author"])
+        # -> {"success": False, "error": {"code": "MISSING_FIELDS",
+        #      "message": "Missing required fields: title, author",
+        #      "missing_fields": ["title", "author"]}}
+    """
+    if isinstance(fields, str):
+        field_list = [f.strip() for f in fields.split(",") if f.strip()]
+    else:
+        field_list = [str(f).strip() for f in fields if str(f).strip()]
+
     return error_response(
         ErrorCodes.MISSING_FIELDS,
-        f"Missing required fields: {fields}",
-        400
+        f"Missing required fields: {', '.join(field_list)}",
+        400,
+        additional_data={"missing_fields": field_list}
     )
 
 

--- a/frontend/css/contributing.css
+++ b/frontend/css/contributing.css
@@ -708,8 +708,6 @@ body {
 }
 
 *:hover {
-html,
-body {
     cursor: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 24 24'><path fill='%23ffca3a' d='M4.42 20.58a1 1 0 0 0 1.41 0L15.24 11.2l-2.44-2.44L3.42 18.17a1 1 0 0 0 0 1.41zM17.36 9.08l-2.44-2.44 2.12-2.12a2 2 0 0 1 2.83 0l1.77 1.77a2 2 0 0 1 0 2.83z'/><path stroke='%23ffca3a' stroke-width='1.5' d='M2 22l4-1'/></svg>") 0 24, pointer !important;
 }
 
@@ -1594,8 +1592,6 @@ body {
 /* PENCIL CURSOR ANIMATION */
 
 body.landing-page {
-html,
-body {
   cursor: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="%235d4037" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.83 2.83 0 1 1 4 4L7.5 20.5a4 4 0 0 1-2.5.88H2v-4.5a4 4 0 0 1 .88-2.5L17 3"></path></svg>') 5 1, auto;
 }
 
@@ -1707,8 +1703,6 @@ body {
 
 /* Pencil cursor for dark mode */
 [data-theme="night"] body.landing-page {
-html,
-body {
   cursor: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="%23d9c0a7" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.83 2.83 0 1 1 4 4L7.5 20.5a4 4 0 0 1-2.5.88H2v-4.5a4 4 0 0 1 .88-2.5L17 3"></path></svg>') 5 1, auto;
 }
 


### PR DESCRIPTION
## Description
`missing_fields_error` in `backend/core/responses/error_responses.py` now reports **which** fields are missing instead of a generic message. It accepts a list of field names (or a single/comma-separated string), normalizes them, and includes a structured `missing_fields` array in the error payload.

Example response:
```json
{
  "success": false,
  "error": {
    "code": "MISSING_FIELDS",
    "message": "Missing required fields: title, author",
    "missing_fields": ["title", "author"]
  }
}
```

Note: `missing_fields` is nested under `error` to stay consistent with `error_response()`, the shared formatter used by every error helper in this module (all responses follow `{success, error: {code, message, ...}}`).

## Related Issue
Fixes #1335

## Type of Change
- [ ] Bug Fix
- [ ] Feature
- [x] Enhancement
- [ ] Documentation

## Testing
Verified the field-normalization logic handles list input (`["title","author"]`), single string (`"vibe_prompt"`), and comma-separated string (`"a, b, c"`), trimming whitespace and dropping empties. Backward compatible with existing string callers.

## Checklist
- [x] Code follows guidelines
- [x] Tested properly
- [ ] Docs updated
- [x] PR title includes the relevant event tag or a general contribution label